### PR TITLE
[Fix] 프로젝트 실행 에러

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -70,9 +70,11 @@ func makeModule(_ module: Ticlemoa,
 // MARK: - Module
 
 let shareInfoPlist: InfoPlist = .extendingDefault(with: [
+		"CFBundleDisplayName": "\(Ticlemoa.productName)",
+		"CFBundleShortVersionString": "1.0.0",
 		"NSExtension": [
 			"NSExtensionAttributes": [
-				"NSExtensionActivationRule": "TRUEPREDICATE"
+				"NSExtensionActivationSupportsText": true
 			],
 			"NSExtensionMainStoryboard": "MainInterface",
 			"NSExtensionPointIdentifier": "com.apple.share-services"

--- a/Project.swift
+++ b/Project.swift
@@ -111,7 +111,6 @@ let mainAppTarget = [
 		dependencies: [
 			.target(name: Ticlemoa.userInterface.name),
 			.target(name: Ticlemoa.domain.name),
-			.target(name: Ticlemoa.network.name),
 			.target(name: Ticlemoa.share.name)
 //			.swinject
 		]


### PR DESCRIPTION
## 📌 배경
open #4 
open #7 

## 내용
1. `tuist generate` 직후 App 실행시 에러 발생 처리
   > AppExtension_info.plist `"CFBundleDisplayName"` Key값 추가 
   > (App product name)
2.  AppExtension 관련 Warning 처리
    > AppExtension_info.plist - "NSExtensionAttributes" Value값 추가      
    > `"NSExtensionActivationSupportsText" : true`

3. Network 모듈 종속성 수정
   > AppTarget 에만 종속하도록 변경

## 스크린샷 및 참고사항
### AppExtension 관련 Warning 처리3
<img width="1000" alt="스크린샷 2022-11-13 오전 12 03 46" src="https://user-images.githubusercontent.com/24707229/201582914-adaf6b92-9b27-46a6-89ec-e1c2cff36bd5.png">
[참고 블로그](https://m.blog.naver.com/PostView.naver?isHttpsRedirect=true&blogId=horajjan&logNo=220792532434)
에 따르면 AppExtension 생성시 Default Key "NSExtensionActivationRule" 의 Value "TRUEPREDICATE"로 명시 되어있지만 심사 요청 시 리젝 사유 -> 용도에 관한 명시가 필요함.

`"NSExtensionActivationSupportsText" : true` - AppExtension에서 텍스트를 다룸

설정을 추가해서 해당 이슈를 해결했습니다.
> 참고자료
> [애플 공식 Archive - Share Extension Keys/NSExtensionActivationRule](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html#//apple_ref/doc/uid/TP40014212-SW33)
> [애플 공식 Archive - Action Extension Keys/NSExtensionActivationRule](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html#//apple_ref/doc/uid/TP40014212-SW10)

### Network 모듈 종속성 수정
|Before|After|
|:---:|:---:| 
|![graph-before](https://user-images.githubusercontent.com/24707229/201583583-281d13de-82a6-4de6-ad24-9540756d1c72.png)|![graph-after](https://user-images.githubusercontent.com/24707229/201583622-e8390563-52bd-4dcf-8013-09951bf5fa7c.png)|

[Tuist Docs - tuist graph](https://docs.tuist.io/commands/graph)
Tuist 명령어(기능)을 이용해서 현재 프로젝트의 모듈 관계 그래프를 확인 가능해서 사용해보고
Network 모듈의 기대와 다른 종속성을 발견하여 수정했습니다.