### PR TITLE
[Feature] ColorSet 추가

### DIFF
--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/black.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/black.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey1.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.960",
+          "green" : "0.980",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.910",
+          "green" : "0.950",
+          "red" : "0.960"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2Line.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2Line.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.860",
+          "green" : "0.890",
+          "red" : "0.910"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey3.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.710",
+          "green" : "0.750",
+          "red" : "0.760"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey4.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.470",
+          "green" : "0.520",
+          "red" : "0.530"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/primary.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.430",
+          "green" : "0.680",
+          "red" : "0.080"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/white.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/white.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
+++ b/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
@@ -1,0 +1,20 @@
+//
+//  Color+CustomColor.swift
+//  UserInterface
+//
+//  Created by Joseph Cha on 2022/11/26.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+extension Color {
+    static var black: Color { return Color("black") }
+    static var grey1: Color { return Color("grey1") }
+    static var grey2: Color { return Color("grey2") }
+    static var grey2Line: Color { return Color("grey2Line") }
+    static var grey3: Color { return Color("grey3") }
+    static var grey4: Color { return Color("grey4") }
+    static var primary: Color { return Color("primary") }
+    static var white: Color { return Color("white") }
+}


### PR DESCRIPTION
## 📌 배경

open #8

## 내용
- Ticlemoa(App) 모듈의 Assets.xcassets 파일에 ColorSet 추가했습니다. 
- 해당 Assets.xcassets 파일에서 UserInterface 모듈을 타게팅(inspector 영역 target membership 체크)했습니다. UserInterface 모듈에서 접근 가능 하도록요. 
- 추가한 ColorSet에 대한 Color Extension을 UserInterface 모듈에 정의했습니다.

## 테스트 방법 (optional)
```swift
ex) 
     Text("Hello World").foregroundColor(Color.primary)
```
<img width="400" alt="image" src="https://user-images.githubusercontent.com/35060252/204204425-d9a243e8-9b5a-4edc-9284-d7425a56ec49.png">