### PR TITLE
[Feature] 태그 관리 뷰 UI 구성

### DIFF
--- a/Targets/UserInterface/Sources/TagManagingView.swift
+++ b/Targets/UserInterface/Sources/TagManagingView.swift
@@ -1,0 +1,75 @@
+//
+//  TagManagingView.swift
+//  UserInterface
+//
+//  Created by Shin Jae Ung on 2022/11/19.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+struct TagManagingView: View {
+    @ObservedObject private var viewModel: TagManagingViewModel
+    
+    init(tags: [String]) {
+        self.viewModel = TagManagingViewModel(tags: tags)
+    }
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(viewModel.tags, id: \.self) { name in
+                    TagView(name: name, isNew: true)
+                }
+            }
+        }
+        .navigationTitle("태그관리")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Image(systemName: "plus")
+            }
+        }
+    }
+}
+
+fileprivate class TagManagingViewModel: ObservableObject {
+    @Published var tags: [String]
+    
+    init(tags: [String]) {
+        self.tags = tags
+    }
+}
+
+fileprivate struct TagView: View {
+    let name: String
+    let isNew: Bool
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text(name)
+                if isNew {
+                    Text("N")
+                        .foregroundColor(.gray)
+                }
+                Spacer()
+                Image(systemName: "ellipsis")
+            }
+            .padding()
+            Divider()
+                .foregroundColor(.gray)
+        }
+    }
+}
+
+struct TagManageView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            NavigationLink("눌러") {
+                TagManagingView(tags: "ABCDEFGHIJKLMN".map{ String($0) })
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## 📌 배경

close #20

## 내용
- 태그 관리 뷰 UI를 간단하게 구성해 보았습니다.
- Back button은 UINavigationAppearence를 이용해 전체 화면에 적용할 수 있기 때문에 변경하지 않았습니다.
- N(새로 추가된 태그임을 나타냄)을 어떻게 받아야할지 Backend developer와 논의가 필요합니다.

## 테스트 방법 (optional)
- Preview를 이용해 확인하시면 됩니다.
- Navigation까지 확인하기 용이하시도록 Preview에 Navigation을 넣어 두었습니다.

## 스크린샷 (optional)

<img width=360 src="https://user-images.githubusercontent.com/81242125/204545060-33d1ece2-0855-4dd4-9b7d-9f2f762083c4.jpeg">


