### PR TITLE
[Feature] 프로필 설정 UI 및 마이페이지 UI, Navigation 설정

### DIFF
--- a/Targets/UserInterface/Sources/MyPageView.swift
+++ b/Targets/UserInterface/Sources/MyPageView.swift
@@ -11,17 +11,29 @@ import SwiftUI
 struct MyPageView: View {
     var body: some View {
         VStack(spacing: 0) {
-            Circle()
-                .frame(width: 75, height: 75)
-                .padding(.top, 40)
-            HStack(spacing: 0) {
-                Text("가나다라마바사")
-                Image(systemName: "highlighter")
+            NavigationLink {
+                ProfileSettingView()
+            } label: {
+                VStack(spacing: 0) {
+                    Circle()
+                        .frame(width: 59, height: 59)
+                        .padding(.top, 18)
+                        .padding(.bottom, 12)
+                    HStack(spacing: 0) {
+                        Text("가나다라마바사")
+                            .foregroundColor(.black)
+                            .font(.system(size: 16))
+                            .fontWeight(.semibold)
+                        Image(systemName: "highlighter")
+                    }
+                    Text("asdf12345@gmail.com")
+                        .tint(.grey3)
+                        .padding(.top, 2)
+                        .padding(.bottom, 14)
+                }
             }
-            .padding(6)
-            Text("asdf12345@gmail.com")
-                .accentColor(.gray)
-                .padding(.bottom, 32)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 81)
             
             VStack(spacing: 0) {
                 MyPageNavigationView(imageName: "bell", title: "알림")

--- a/Targets/UserInterface/Sources/ProfileSettingView.swift
+++ b/Targets/UserInterface/Sources/ProfileSettingView.swift
@@ -1,0 +1,85 @@
+//
+//  ProfileSettingView.swift
+//  Ticlemoa
+//
+//  Created by Shin Jae Ung on 2022/12/02.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+struct ProfileSettingView: View {
+    @State private var nickname: String = ""
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Circle()
+                .frame(width: 59, height: 59)
+                .padding(.top, 24)
+                .overlay {
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Image(systemName: "gearshape.circle.fill")
+                                .resizable()
+                                .foregroundColor(.gray)
+                                .scaledToFit()
+                                .frame(width: 20, height: 20)
+                                .background {
+                                    Circle()
+                                        .foregroundColor(.white)
+                                        .frame(width: 22, height: 22)
+                                }
+                        }
+                    }
+                }
+            
+            VStack(spacing: 0) {
+                HStack {
+                    Text("닉네임")
+                        .foregroundColor(.grey4)
+                        .font(.system(size: 14))
+                    Spacer()
+                }
+                .padding(.bottom, 12)
+                TextField("닉네임을 입력해주세요.", text: self.$nickname)
+                    .padding(.bottom, 8)
+                Divider()
+                    .padding(.bottom, 8.8)
+                HStack {
+                    Spacer()
+                    Text("\(nickname.count)/10")
+                        .foregroundColor(.grey4)
+                        .font(.system(size: 14))
+                }
+            }
+            .padding(20)
+            
+            Spacer()
+        }
+        .navigationTitle("프로필 설정")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("완료") {
+                    Void()
+                }
+                .foregroundColor(.black)
+            }
+        }
+    }
+}
+
+struct ProfileSettingView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            NavigationLink {
+                ProfileSettingView()
+            } label: {
+                Text("Button")
+            }
+        }
+        ProfileSettingView()
+    }
+}


### PR DESCRIPTION
## 📌 배경

close #27

## 내용
- 마이페이지 UI를 조금 더 피그마와 유사하게 변경하였습니다.
- 마이페이지에서 다음 화면인 프로필 설정 화면으로 넘어가는 Navigation을 설정하였습니다.
- 프로필 설정 화면 UI를 그렸습니다.

## 테스트 방법 (optional)
- Preview 확인 혹은 MyPage 화면을 시뮬레이터에서 실행

## 스크린샷 (optional)

|요셉님 피드백 전|요셉님 피드백 후|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/81242125/205299072-adf7099d-f949-45c1-b0d1-d7b1785d08d8.gif">|<img src="https://user-images.githubusercontent.com/81242125/205938540-f973e2c2-c593-480e-a3fa-35f6c9127a71.gif">|

