### PR TITLE
[Feature] 계정삭제 Modal UI 구성

### DIFF
--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/secondaryRed.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/secondaryRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.333",
+          "green" : "0.310",
+          "red" : "0.918"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Targets/UserInterface/Sources/MyPageView.swift
+++ b/Targets/UserInterface/Sources/MyPageView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct MyPageView: View {
+    @State private var isAccountDeleteButtonTouched: Bool = false
+    
     var body: some View {
         VStack(spacing: 0) {
             NavigationLink {
@@ -72,7 +74,7 @@ struct MyPageView: View {
             .padding(.horizontal, 13)
 
             Button(role: .destructive) {
-                Void()
+                isAccountDeleteButtonTouched = true
             } label: {
                 HStack {
                     Text("계정삭제")
@@ -86,10 +88,14 @@ struct MyPageView: View {
         }
         .navigationTitle("마이페이지")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isAccountDeleteButtonTouched) {
+            MyPageAccountDeletingView()
+                .presentationDetents([.medium])
+        }
     }
 }
 
-struct MyPageNavigationView: View {
+fileprivate struct MyPageNavigationView: View {
     let imageName: String
     let title: String
     
@@ -112,7 +118,85 @@ struct MyPageNavigationView: View {
     }
 }
 
-struct MyPage_Previews: PreviewProvider {
+fileprivate struct MyPageAccountDeletingView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Capsule()
+                .foregroundColor(.black)
+                .frame(width: 42, height: 4)
+                .padding(18)
+            Text("계정삭제")
+                .font(.system(size: 18))
+                .fontWeight(.bold)
+                .padding(.top, 6.5)
+                .padding(.bottom, 30.5)
+            Spacer()
+                .background(Rectangle())
+                .padding(.horizontal, 36)
+            VStack(spacing: 0) {
+                HStack {
+                    Text("정말로 계정을 삭제하시겠어요?")
+                        .font(.system(size: 18))
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+                .padding(.vertical, 4.5)
+                .padding(.bottom, 4)
+                
+                HStack {
+                    Text("N개의 콘텐츠가 모두 삭제되고, 계정은 복구할 수 없어요")
+                        .font(.system(size: 14))
+                        .fontWeight(.medium)
+                        .foregroundColor(.grey4)
+                    Spacer()
+                }
+                .padding(.vertical, 3.5)
+            }
+            .padding(.vertical, 24)
+            .padding(.horizontal, 36)
+            HStack(spacing: 11) {
+                Button {
+                    Void()
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("취소")
+                            .foregroundColor(.black)
+                            .font(.system(size: 16))
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                    .padding(20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .foregroundColor(.grey2Line)
+                    )
+                }
+                Button {
+                    Void()
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("삭제")
+                            .foregroundColor(.white)
+                            .font(.system(size: 16))
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                    .padding(20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .foregroundColor(.secondaryRed)
+                    )
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 16)
+        }
+    }
+}
+
+struct MyPageView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             NavigationLink {

--- a/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
+++ b/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
@@ -17,4 +17,5 @@ extension Color {
     static var grey4: Color { return Color("grey4") }
     static var primary: Color { return Color("primary") }
     static var white: Color { return Color("white") }
+    static var secondaryRed: Color { return Color("secondaryRed")}
 }


### PR DESCRIPTION
## 📌 배경

close #28

## 내용
- 계정 삭제 화면의 UI와 마이페이지 화면에서 계정삭제 버튼 기능 동작

## 테스트 방법 (optional)
- 마이페이지 View에서 계정삭제를 누르면 확인 가능합니다.

## 스크린샷 (optional)

|피그마|구현|
|:-:|:-:|
|<img width=200 src="https://user-images.githubusercontent.com/81242125/205348620-ef7673c5-965c-45de-87c8-052ec5f42355.jpeg">|<img width=200 src="https://user-images.githubusercontent.com/81242125/205349302-680cb567-bd70-4fa9-8a84-b7854bb70923.jpeg">|
