### PR TITLE
[Feature] 마이페이지 알림설정 UI 구성

### DIFF
--- a/Targets/UserInterface/Sources/MyPage/AlertSettingView.swift
+++ b/Targets/UserInterface/Sources/MyPage/AlertSettingView.swift
@@ -1,0 +1,47 @@
+//
+//  AlertSettingView.swift
+//  UserInterface
+//
+//  Created by Shin Jae Ung on 2022/12/17.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlertSettingView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: 12)
+            AlertSettingButtonView(title: "푸시알림") { isOn in
+                print("button tapped with value = \(isOn)")
+            }
+            Spacer()
+        }
+        .setupBackground()
+        .navigationTitle("알림")
+    }
+}
+
+fileprivate struct AlertSettingButtonView: View {
+    let title: String
+    let onTap: (Bool) -> ()
+    
+    init(title: String, onTap: @escaping (Bool) -> Void) {
+        self.title = title
+        self.onTap = onTap
+    }
+    
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 16))
+                .fontWeight(.medium)
+            Spacer()
+            TiclemoaButton(onTap: onTap)
+        }
+        .foregroundColor(.ticlemoaBlack)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 20)
+    }
+}

--- a/Targets/UserInterface/Sources/MyPage/MyPageView.swift
+++ b/Targets/UserInterface/Sources/MyPage/MyPageView.swift
@@ -39,7 +39,7 @@ struct MyPageView: View {
             
             VStack(spacing: 0) {
                 MyPageNavigationView(imageName: "bell", title: "알림") {
-                    EmptyView()
+                    AlertSettingView()
                 }
                 MyPageNavigationView(imageName: "info.circle", title: "서비스 정보") {
                     ServiceInformationView()

--- a/Targets/UserInterface/Sources/Utils/TiclemoaButton.swift
+++ b/Targets/UserInterface/Sources/Utils/TiclemoaButton.swift
@@ -1,0 +1,48 @@
+//
+//  TiclemoaButton.swift
+//  UserInterface
+//
+//  Created by Shin Jae Ung on 2022/12/17.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+struct TiclemoaButton: View {
+    @State private var _isOn = true
+    let onTap: (Bool) -> ()
+    var isOn: Bool {
+        get { self._isOn }
+    }
+    
+    init(isOn: Bool = true, onTap: @escaping (Bool) -> Void) {
+        self._isOn = isOn
+        self.onTap = onTap
+    }
+    
+    var body: some View {
+        ZStack {
+            Capsule()
+                .foregroundColor(isOn ? .ticlemoaBlack : .grey2Line)
+                .offset(x: 0, y: 0)
+            HStack {
+                if isOn {
+                    Spacer()
+                }
+                Circle()
+                    .foregroundColor(.white)
+                    .padding(1)
+                if !isOn {
+                    Spacer()
+                }
+            }
+        }
+        .frame(width: 39, height: 24)
+        .onTapGesture {
+            withAnimation {
+                _isOn.toggle()
+                onTap(isOn)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 배경

close #59

## 내용
- 마이페이지에서 알람설정 화면 넘어가는 navigation
- 알람설정화면 UI 구성
- Custom Button인 TiclemoaButton 구성
- Navigation Bar는 추후 변경 예정입니다.

## 테스트 방법 (optional)
- Preview 확인 혹은 MyPage 화면을 시뮬레이터에서 실행

## 스크린샷 (optional)

|피그마|구현|
|:-:|:-:|
|<img width=360 src="https://user-images.githubusercontent.com/81242125/208230091-a55ae689-4b63-495b-87a7-b0094d5fabb2.jpg">|<img width=360 src="https://user-images.githubusercontent.com/81242125/208230093-29576558-52a3-4dc0-858c-dcc850af7161.png">|

