### PR TITLE
[Feature] TiclemoaNavigationBar 구현

### DIFF
--- a/Targets/UserInterface/Sources/Utils/Extensions/View+Extension.swift
+++ b/Targets/UserInterface/Sources/Utils/Extensions/View+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  View+Extension.swift
+//  UserInterface
+//
+//  Created by Shin Jae Ung on 2022/12/20.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    func ticlemoaNavigationBar(
+        title: String,
+        @ViewBuilder trailingItem: @escaping () -> (some View) = { EmptyView() }
+    ) -> some View {
+        return modifier(TiclemoaNavigationBar(title: title, trailingItem: trailingItem))
+    }
+}

--- a/Targets/UserInterface/Sources/Utils/TiclemoaNavigationBar.swift
+++ b/Targets/UserInterface/Sources/Utils/TiclemoaNavigationBar.swift
@@ -1,0 +1,45 @@
+//
+//  TiclemoaNavigationBar.swift
+//  UserInterface
+//
+//  Created by Shin Jae Ung on 2022/12/20.
+//  Copyright © 2022 nyongnyong. All rights reserved.
+//
+
+import SwiftUI
+
+struct TiclemoaNavigationBar<Item: View>: ViewModifier {
+    @Environment(\.dismiss) private var dismiss
+    private let title: String
+    private let trailingItem: () -> Item
+    
+    init(title: String, @ViewBuilder trailingItem: @escaping () -> Item) {
+        self.title = title
+        self.trailingItem = trailingItem
+    }
+    
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            ZStack {
+                HStack(alignment: .center) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image("arrow")
+                            .frame(width: 9.29, height: 15.8)
+                    }
+                    .padding(.leading, 26.52)
+                    Spacer()
+                    trailingItem().padding(.trailing, 20)
+                }
+                Text(title)
+                    .customFont(18, .bold)
+            }
+            .frame(height: 56)
+            Spacer()
+            content
+                .toolbar(.hidden)
+            Spacer()
+        }
+    }
+}


### PR DESCRIPTION
## 📌 배경

close #69

## 내용
- 기존의 navigationBar를 대체하는 TiclemoaNavigationBar 구현
- ticlemoaNavigationBar viewModifier로 기존의 navigationBarTitle과 유사한 API 제공
- trailingItem을 추가 가능하도록 하여 toolBarItem 역할을 할 수 있게 구현
- navigation title의 weight는 bold로 처리했으나 아직 font가 미적용되어 있습니다.

## 테스트 방법 (optional)
- View에서 .ticlemoaNavigationBar(title:,trailingItem:) 함수를 실행

## 스크린샷 (optional)

<img width=600 src="https://user-images.githubusercontent.com/81242125/208674030-3ccecc31-9398-4f9c-bae9-eae87e4009af.gif">
