### PR TITLE
[Fix] No image named 'alarm' 버그 해결

### DIFF
--- a/Targets/UserInterface/Sources/MainTab/MainTabView.swift
+++ b/Targets/UserInterface/Sources/MainTab/MainTabView.swift
@@ -69,7 +69,7 @@ struct MainTabView: View {
                     NavigationLink(
                         destination: AlarmView(),
                         label: {
-                            Image("alarm")
+                            Image("Bell")
                         })
                     NavigationLink(destination: ProfileView(), label: {
                         Image("defaultProfile")

--- a/Targets/UserInterface/Sources/MyPage/MyPageView.swift
+++ b/Targets/UserInterface/Sources/MyPage/MyPageView.swift
@@ -56,7 +56,7 @@ struct MyPageView: View {
             .padding(.horizontal, 81)
             
             VStack(spacing: 0) {
-                MyPageNavigationView(imageName: "bell", title: "알림") {
+                MyPageNavigationView(imageName: "Bell", title: "알림") {
                     AlertSettingView()
                 }
                 MyPageNavigationView(imageName: "Information", title: "서비스 정보") {


### PR DESCRIPTION
## 📌 배경

close #68

## 내용
- 이미지로 alarm이 아닌 Bell을 호출하도록 함
- No image named 'defaultProfile' 버그는 해결하지 않았습니다
  - 이유는 #74에서 defaultProfile을 path로 그렸기 때문

## 테스트 방법 (optional)
- 실행시 console에 No image named 'alarm' 구문이 나오지 않으면 성공