### PR TITLE
[Fix] 색상 일치화 및 신규 색상 추가

### DIFF
--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey1.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.960",
-          "green" : "0.980",
-          "red" : "1.000"
+          "blue" : "0xF5",
+          "green" : "0xFB",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.910",
-          "green" : "0.950",
-          "red" : "0.960"
+          "blue" : "0xE9",
+          "green" : "0xF1",
+          "red" : "0xF4"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2Line.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey2Line.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.860",
-          "green" : "0.890",
-          "red" : "0.910"
+          "blue" : "0xDC",
+          "green" : "0xE3",
+          "red" : "0xE7"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey3.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey3.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.710",
-          "green" : "0.750",
-          "red" : "0.760"
+          "blue" : "0xB5",
+          "green" : "0xBE",
+          "red" : "0xC1"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey4.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/grey4.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.470",
-          "green" : "0.520",
-          "red" : "0.530"
+          "blue" : "0x79",
+          "green" : "0x85",
+          "red" : "0x88"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaBlack.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaBlack.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.200",
-          "green" : "0.200",
-          "red" : "0.200"
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaPrimary2.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaPrimary2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x6D",
-          "green" : "0xAD",
-          "red" : "0x14"
+          "blue" : "0x72",
+          "green" : "0xC5",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaWhite.colorset/Contents.json
+++ b/Targets/Ticlemoa/Resources/Assets.xcassets/ColorSets/ticlemoaWhite.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
+++ b/Targets/UserInterface/Sources/Utils/Extensions/Color+CustomColor.swift
@@ -16,6 +16,7 @@ extension Color {
     static var grey4: Color { return Color("grey4") }
     static var ticlemoaBlack: Color { return Color("ticlemoaBlack") }
     static var ticlemoaPrimary: Color { return Color("ticlemoaPrimary") }
+    static var ticlemoaPrimary2: Color { return Color("ticlemoaPrimary2") }
     static var ticlemoaWhite: Color { return Color("ticlemoaWhite") }
     static var secondaryRed: Color { return Color("secondaryRed")}
 }


### PR DESCRIPTION
## 📌 배경

close #83 

## 내용
- 에셋파일 속 ColorSet, Figma 색상들 hex값 일치화
- 신규색상 ticlemoaPrimary2(Figma상 primary green2) 추가

## 스크린샷
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/35060252/209820533-7fc13aef-3e48-4697-911b-e8f09641c646.png">