### PR TITLE
[Fix] 외부 라이브러리 적용 방식 변경

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,0 +1,22 @@
+//
+//  Dependencies.swift
+//  Config
+//
+//  Created by Yongwoo Marco on 2022/12/31.
+//
+
+import ProjectDescription
+
+let dependencies = Dependencies(
+	swiftPackageManager: [
+		.remote(
+			url: "https://github.com/apple/swift-collections.git",
+			requirement: .upToNextMajor(from: "1.0.0")
+		),
+		.remote(
+			url: "https://github.com/kakao/kakao-ios-sdk.git",
+			requirement: .upToNextMajor(from: "2.0.0")
+		)
+	],
+	platforms: [.iOS]
+)

--- a/Tuist/ProjectDescriptionHelpers/Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extension.swift
@@ -7,32 +7,6 @@
 
 import ProjectDescription
 
-public extension TargetDependency {
-//	static let swinject = TargetDependency.package(product: "Swinject")
-    static let swiftCollection = TargetDependency.package(product: "SwiftCollection")
-    static let kakaoSDK = TargetDependency.package(product: "KakaoSDK")
-    static let alamofire = TargetDependency.package(product: "Alamofire")
-}
-
-public extension Package {
-//	static let swinject = Package.remote(
-//		url: "https://github.com/Swinject/Swinject.git",
-//		requirement: .upToNextMajor(from: .init(2, 8, 1))
-//	)
-    static let swiftCollection = Package.remote(
-        url: "https://github.com/apple/swift-collections.git",
-        requirement: .upToNextMajor(from: .init(1, 0, 0))
-    )
-    static let kakaoSDK = Package.remote(
-        url: "https://github.com/kakao/kakao-ios-sdk.git",
-        requirement: .upToNextMajor(from: .init(2, 13, 1))
-    )
-    static let alamofire = Package.remote(
-        url: "https://github.com/Alamofire/Alamofire.git",
-        requirement: .upToNextMajor(from: .init(5, 6, 1))
-    )
-}
-
 // MARK: - SourceFile
 public extension SourceFilesList {
 	static let sources: SourceFilesList = "Sources/**"


### PR DESCRIPTION
## 📌 배경

close #94 

## 내용
- [Tuist Doc - 외부 의존성 추가](https://docs.tuist.io/guides/third-party-dependencies)
- [Tuist 로 외부 의존성 관리하기](https://okanghoon.medium.com/tuist-%EB%A1%9C-%EC%99%B8%EB%B6%80-%EC%9D%98%EC%A1%B4%EC%84%B1-%EA%B4%80%EB%A6%AC%ED%95%98%EA%B8%B0-85609e70133c)
   > 위 블로그를 참고해서 제가 처음 작성한 방식 이외에 다른 방식  
   > `Dependencies.swift`를 이용한 방식(3.xx 버전 이후 필수) 으로 수정했습니다.

우성님이 처리하신 UserInterface 모듈에 `KakaoSDK`, `Collections` 모두 적용했습니다.

## 테스트 방법 (optional)
#93 에 언급했던
> `tuist generate` 전에 아래 사항을 먼저 처리해야합니다  
> 1. `tuist clean` 캐시삭제
> 2. `tuist fetch `라이브러리 불러오기 -> `Tuist/Dependencies` 디렉토리 생성됨
> 3. `tuist generate` 프로젝트 생성

위 순서로 프로젝트 생성해주셔야합니다.