### PR TITLE
[fix] Tuist 모듈 의존성 수정

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -7,26 +7,26 @@ let localHelper = LocalHelper(name: "MyPlugin")
 
 // MARK: - Project String Data
 enum Ticlemoa: String {
-	static let projectName = "Ticlemoa"
-	static let productName = "Ticlemoa"
-	static let organizationName = "nyongnyong"
-	static let bundleId = "com.nyongnyong"
-	static let deploymentTarget = DeploymentTarget
-		.iOS(targetVersion: "15.0", devices: [.iphone])
-	
-	case userInterface = "UserInterface"
+    static let projectName = "Ticlemoa"
+    static let productName = "Ticlemoa"
+    static let organizationName = "nyongnyong"
+    static let bundleId = "com.nyongnyong"
+    static let deploymentTarget = DeploymentTarget
+        .iOS(targetVersion: "15.0", devices: [.iphone])
+    
+    case userInterface = "UserInterface"
     case domainInterface = "DomainInterface"
-	case domain = "Domain"
-	case api = "API"
-	case share = "ShareExtension"
-	
-	var name: String { self.rawValue }
-	var product: Product {
-		switch self {
-            case .share:	return .appExtension
+    case domain = "Domain"
+    case api = "API"
+    case share = "ShareExtension"
+    
+    var name: String { self.rawValue }
+    var product: Product {
+        switch self {
+            case .share:    return .appExtension
             default:        return .framework
         }
-	}
+    }
 }
 
 // MARK: - Module
@@ -49,144 +49,152 @@ func interface(_ module: Ticlemoa,
 }
     
 func makeModule(_ module: Ticlemoa,
-				infoPlist: InfoPlist? = nil,
-				dependencies: [TargetDependency],
-				hasTest: Bool
+                infoPlist: InfoPlist? = nil,
+                dependencies: [TargetDependency],
+                hasTest: Bool
 ) -> [Target] {
-	let sources = Target(
-		name: module.name,
-		platform: .iOS,
-		product: module.product,
-		bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)",
-		deploymentTarget: Ticlemoa.deploymentTarget,
-		infoPlist: infoPlist ?? .default,
-		sources: ["Targets/\(module.name)/Sources/**"],
-		resources: ["Targets/\(module.name)/Resources/**"],
-		dependencies: dependencies
-	)
-	if hasTest {
-		let tests = Target(
-			name: "\(module.name)Tests",
-			platform: .iOS,
-			product: .unitTests,
-			bundleId: "\(Ticlemoa.bundleId).DomainTests",
-			deploymentTarget: Ticlemoa.deploymentTarget,
-			infoPlist: .default,
-			sources: ["Targets/\(module.name)/Tests/**"],
-			resources: [],
-			dependencies: [
-				.target(name: "\(module.name)")
-			]
-		)
-		return [sources, tests]
-	} else {
-		return [sources]
-	}
+    let sources = Target(
+        name: module.name,
+        platform: .iOS,
+        product: module.product,
+        bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)",
+        deploymentTarget: Ticlemoa.deploymentTarget,
+        infoPlist: infoPlist ?? .default,
+        sources: ["Targets/\(module.name)/Sources/**"],
+        resources: ["Targets/\(module.name)/Resources/**"],
+        dependencies: dependencies
+    )
+    if hasTest {
+        let tests = Target(
+            name: "\(module.name)Tests",
+            platform: .iOS,
+            product: .unitTests,
+            bundleId: "\(Ticlemoa.bundleId).DomainTests",
+            deploymentTarget: Ticlemoa.deploymentTarget,
+            infoPlist: .default,
+            sources: ["Targets/\(module.name)/Tests/**"],
+            resources: [],
+            dependencies: [
+                .target(name: module.name)
+            ]
+        )
+        return [sources, tests]
+    } else {
+        return [sources]
+    }
 }
 
 // MARK: - Module
 
 let shareInfoPlist: InfoPlist = .extendingDefault(with: [
-		"CFBundleDisplayName": "\(Ticlemoa.productName)",
-		"CFBundleShortVersionString": "1.0.0",
-		"NSExtension": [
-			"NSExtensionAttributes": [
-				"NSExtensionActivationSupportsText": true
-			],
-			"NSExtensionMainStoryboard": "MainInterface",
-			"NSExtensionPointIdentifier": "com.apple.share-services"
-		]
-	]
+        "CFBundleDisplayName": "\(Ticlemoa.productName)",
+        "CFBundleShortVersionString": "1.0.0",
+        "NSExtension": [
+            "NSExtensionAttributes": [
+                "NSExtensionActivationSupportsText": true
+            ],
+            "NSExtensionMainStoryboard": "MainInterface",
+            "NSExtensionPointIdentifier": "com.apple.share-services"
+        ]
+    ]
 )
 
 let userInterface = makeModule(
-	.userInterface,
-	dependencies: [
-		.external(name: "KakaoSDK"),
-		.external(name: "Collections")
-	],
-	hasTest: true
+    .userInterface,
+    dependencies: [
+        .target(name: Ticlemoa.domainInterface.name),
+        .external(name: "KakaoSDK"),
+        .external(name: "Collections")
+    ],
+    hasTest: true
 )
 let api = makeModule(
-	.api,
-	dependencies: [],
-	hasTest: true
+    .api,
+    dependencies: [],
+    hasTest: true
 )
 let domain = makeModule(
-	.domain,
-	dependencies: [
-		.target(name: Ticlemoa.api.name)
-	],
-	hasTest: true
+    .domain,
+    dependencies: [
+        .target(name: Ticlemoa.api.name),
+        .target(name: Ticlemoa.domainInterface.name)
+    ],
+    hasTest: true
 )
 let share = makeModule(
-	.share,
-	infoPlist: shareInfoPlist,
-	dependencies: [],
-	hasTest: false
+    .share,
+    infoPlist: shareInfoPlist,
+    dependencies: [],
+    hasTest: false
+)
+let domainInterface = makeModule(
+    .domainInterface,
+    dependencies: [],
+    hasTest: false
 )
 
 // MARK: - Project
 
 let infoPlist: InfoPlist = .extendingDefault(with: [
-		"CFBundleShortVersionString": "1.0.0",
-		"CFBundleVersion": "1",
-		"UIMainStoryboardFile": "",
-		"UISupportedInterfaceOrientations" : ["UIInterfaceOrientationPortrait"],
-		"UILaunchStoryboardName": "LaunchScreen",
-		"NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
-		"LSApplicationQueriesSchemes" : [
-			"kakaokompassauth",
-			"kakaolink"
-		]
-	]
+        "CFBundleShortVersionString": "1.0.0",
+        "CFBundleVersion": "1",
+        "UIMainStoryboardFile": "",
+        "UISupportedInterfaceOrientations" : ["UIInterfaceOrientationPortrait"],
+        "UILaunchStoryboardName": "LaunchScreen",
+        "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
+        "LSApplicationQueriesSchemes" : [
+            "kakaokompassauth",
+            "kakaolink"
+        ]
+    ]
 )
 
 let mainAppTarget = [
-	Target.init(
-		name: Ticlemoa.projectName,
-		platform: .iOS,
-		product: .app,
-		productName: Ticlemoa.productName,
-		bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)",
-		deploymentTarget: Ticlemoa.deploymentTarget,
-		infoPlist: infoPlist,
-		sources: ["Targets/\(Ticlemoa.projectName)/Sources/**"],
-		resources: ["Targets/\(Ticlemoa.projectName)/Resources/**"],
-		dependencies: [
-			.target(name: Ticlemoa.userInterface.name),
-			.target(name: Ticlemoa.domain.name),
-			.target(name: Ticlemoa.share.name)
-		]
-	),
-	Target.init(
-		name: "\(Ticlemoa.projectName)Tests",
-		platform: .iOS,
-		product: .unitTests,
-		bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)Tests",
-		deploymentTarget: Ticlemoa.deploymentTarget,
-		infoPlist: .default,
-		sources: ["Targets/\(Ticlemoa.projectName)/Tests/**"],
-		scripts: [],
-		dependencies: [
-			.target(name: Ticlemoa.projectName),
-		],
-		settings: nil,
-		coreDataModels: [],
-		environment: [:],
-		launchArguments: [],
-		additionalFiles: []
-	)
+    Target.init(
+        name: Ticlemoa.projectName,
+        platform: .iOS,
+        product: .app,
+        productName: Ticlemoa.productName,
+        bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)",
+        deploymentTarget: Ticlemoa.deploymentTarget,
+        infoPlist: infoPlist,
+        sources: ["Targets/\(Ticlemoa.projectName)/Sources/**"],
+        resources: ["Targets/\(Ticlemoa.projectName)/Resources/**"],
+        dependencies: [
+            .target(name: Ticlemoa.userInterface.name),
+            .target(name: Ticlemoa.domain.name),
+            .target(name: Ticlemoa.share.name)
+        ]
+    ),
+    Target.init(
+        name: "\(Ticlemoa.projectName)Tests",
+        platform: .iOS,
+        product: .unitTests,
+        bundleId: "\(Ticlemoa.bundleId).\(Ticlemoa.projectName)Tests",
+        deploymentTarget: Ticlemoa.deploymentTarget,
+        infoPlist: .default,
+        sources: ["Targets/\(Ticlemoa.projectName)/Tests/**"],
+        scripts: [],
+        dependencies: [
+            .target(name: Ticlemoa.projectName),
+        ],
+        settings: nil,
+        coreDataModels: [],
+        environment: [:],
+        launchArguments: [],
+        additionalFiles: []
+    )
 ]
 
 let project = Project.init(
-	name: Ticlemoa.projectName,
-	organizationName: Ticlemoa.organizationName,
-	targets: [
-		mainAppTarget,
-		userInterface,
-		domain,
-		api,
-		share
-	].flatMap { $0 }
+    name: Ticlemoa.projectName,
+    organizationName: Ticlemoa.organizationName,
+    targets: [
+        mainAppTarget,
+        userInterface,
+        domain,
+        api,
+        share,
+        domainInterface
+    ].flatMap { $0 }
 )

--- a/Targets/API/Sources/HTTPMethod.swift
+++ b/Targets/API/Sources/HTTPMethod.swift
@@ -39,7 +39,7 @@ struct TiclemoaURLRequest {
     func makeURLRequest() -> URLRequest {
         return {
             var request = URLRequest(url: url)
-            request.httpMethod = httpMethod
+            request.httpMethod = httpMethod.rawValue
             // ..
             return request
         }()

--- a/Targets/DomainInterface/Resources/Localizable.strings
+++ b/Targets/DomainInterface/Resources/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  Ticlemoa
+
+  Created by Yongwoo Marco on 2022/11/11.
+  Copyright © 2022 nyongnyong. All rights reserved.
+*/


### PR DESCRIPTION
## 📌 배경

close #99

## 내용
### 누락된 사항
외부 라이브러리 의존성 주입 구현 과정으로
> 타겟을 가리키는 모듈 이름 문자열을 넘겨주던 방식에서  -> `.target(name: 모듈 이름 문자열)` 

형태로 변경하는 과정에서 `DomainInterface` 모듈 생성 및 의존성 주입을 누락했습니다.
위 부분을 수정해서 `import DomainInterface`가 동작하도록 수정했습니다.
### 컴파일 에러 처리
- DomainInteface/Resource 폴더 생성 + Localizable.strings 추가
- API/Sources/HTTP.Method.swift 에러 처리

## 스크린샷 
빌드가 가능한 상태 확인했습니다!
|Article 사용자 타입 명 중복 에러|주석처리로 Article 중복 및 기타 View 에러 가렸을때|
|:--:|:--:| 
| ![이미지 2023  1  2  오전 12 40](https://user-images.githubusercontent.com/24707229/210176805-feded78d-5f63-4bbc-bdc8-b50e4ab1dff1.jpg) | ![이미지 2023  1  2  오전 12 34](https://user-images.githubusercontent.com/24707229/210176814-7aaea476-6a6f-40e6-ae04-8b5d343f5192.jpg) |   
