### PR TITLE
[Refactor] ButtomSheetView 나누기, 접근제어자 수정

### DIFF
--- a/Targets/UserInterface/Sources/Utils/BottomSheetView.swift
+++ b/Targets/UserInterface/Sources/Utils/BottomSheetView.swift
@@ -12,9 +12,9 @@ struct BottomSheetView<Content: View>: View {
     @Binding private var isPresent: Bool
     @State private var backgroundOpacity: Double = 0
     @State private var viewYOffset: Double = UIScreen.main.bounds.height
-    @Environment(\.dismiss) var dismiss
-    var content: () -> (Content)
-    let isHandlebarHidden: Bool
+    @Environment(\.dismiss) private var dismiss
+    private var content: () -> (Content)
+    private let isHandlebarHidden: Bool
 
     init(isPresent: Binding<Bool>, withHandleBar: Bool = false, @ViewBuilder content: @escaping () -> (Content)) {
         self._isPresent = isPresent
@@ -29,39 +29,16 @@ struct BottomSheetView<Content: View>: View {
                 .onTapGesture {
                     dismissWithAnimation()
                 }
-            
-            GeometryReader { geometry in
-                VStack(spacing: 0) {
-                    Spacer()
-                    
-                    VStack(spacing: 0) {
-                        Capsule()
-                            .frame(width: 42, height: 4)
-                            .padding(.top, 18)
-                            .padding(.bottom, 4)
-                            .foregroundColor(isHandlebarHidden ? .clear : .ticlemoaBlack)
-                        
-                        content()
-                        
-                        Spacer()
-                            .frame(height: geometry.safeAreaInsets.bottom)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .background(Color.grey1)
-                    .cornerRadius(20, corners: .topLeft)
-                    .cornerRadius(20, corners: .topRight)
-                    .offset(x: 0, y: viewYOffset)
-                    .gesture(drag)
-                }
-                .ignoresSafeArea(.all, edges: [.bottom])
-            }
+            BottomSheet(content: content)
+            .offset(x: 0, y: viewYOffset)
+            .gesture(drag)
         }
         .onAppear {
             identicalWithAnimation()
         }
     }
     
-    var drag: some Gesture {
+    private var drag: some Gesture {
         DragGesture()
             .onChanged { value in
                 if value.translation.height > 0 {
@@ -96,6 +73,42 @@ struct BottomSheetView<Content: View>: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 dismiss()
             }
+        }
+    }
+}
+
+public struct BottomSheet<Content: View>: View {
+    private var content: () -> (Content)
+    private let isHandlebarHidden: Bool
+    
+    public init(withHandleBar: Bool = false, @ViewBuilder content: @escaping () -> (Content)) {
+        self.isHandlebarHidden = !withHandleBar
+        self.content = content
+    }
+    
+    public var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                Spacer()
+                
+                VStack(spacing: 0) {
+                    Capsule()
+                        .frame(width: 42, height: 4)
+                        .padding(.top, 18)
+                        .padding(.bottom, 4)
+                        .foregroundColor(isHandlebarHidden ? .clear : .ticlemoaBlack)
+                    
+                    content()
+                    
+                    Spacer()
+                        .frame(height: geometry.safeAreaInsets.bottom)
+                }
+                .frame(maxWidth: .infinity)
+                .background(Color.grey1)
+                .cornerRadius(20, corners: .topLeft)
+                .cornerRadius(20, corners: .topRight)
+            }
+            .ignoresSafeArea(.all, edges: [.bottom])
         }
     }
 }


### PR DESCRIPTION
## 📌 배경

close #64

## 내용
- 접근제어자를 다듬었습니다.
- ShareExtensionViewController에 적용하기 위해 필요한 부분을 public 처리하였습니다.
  - ShareExtension의 경우 기본적으로 뒷 배경이 까맣게 처리되어 있기에 중복된 부분을 없애는 부분이 필요합니다.
  - ShareExtension의 경우 기본적으로 pan gesture가 적용되기에 yOffset을 변경해줄 필요가 없습니다.
    - 이 때문에 `dismiss`나 `@Binding isPresent: Bool`도 불필요합니다.
    - View가 적당히 내려가면(특정 속도 이상으로 내려가면) 자동으로 dismiss 됩니다.