### PR TITLE
[Refactor] HomeView 및 Tag 마이그레이션

### DIFF
--- a/Targets/Domain/Sources/Entity/TagData.swift
+++ b/Targets/Domain/Sources/Entity/TagData.swift
@@ -1,6 +1,6 @@
 //
 //  TagData.swift
-//  API
+//  Domain
 //
 //  Created by 김용우 on 2022/12/16.
 //  Copyright © 2022 nyongnyong. All rights reserved.

--- a/Targets/Domain/Sources/Model/TagModel.swift
+++ b/Targets/Domain/Sources/Model/TagModel.swift
@@ -1,6 +1,6 @@
 //
 //  TagModel.swift
-//  API
+//  Domain
 //
 //  Created by 김용우 on 2022/12/16.
 //  Copyright © 2022 nyongnyong. All rights reserved.
@@ -11,9 +11,24 @@ import Foundation
 import API
 import DomainInterface
 
+extension TagData {
+    static var dummy: [Self] {
+        [
+            "전체", "빨간라인", "넘으면", "내려감", "디자인",
+            "MD", "커리어고민", "CS/CX", "인간관계", "개발",
+            "마케팅", "서비스기획", "조직문화", "IT/기술", "취업 이직",
+            "회사생활", "라이프스타일", "경영/젼략"
+        ].enumerated().map({
+            .init(id: UUID(), name: $0.element, articleIds: [], created: .init() + Double($0.offset))
+        })
+    }
+}
+
 public final class TagModel: TagModelProtocol {
     
-    @Published public var items: [Tag] = []
+    public var itemsPublisher: Published<[DomainInterface.Tag]>.Publisher { $items }
+    
+    @Published private var items: [Tag] = TagData.dummy
     
     public init() {
         

--- a/Targets/DomainInterface/Sources/Model/TagModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/TagModelProtocol.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2022 nyongnyong. All rights reserved.
 //
 
+import Combine
+
 public protocol TagModelProtocol {
-    var items: [Tag] { get }
+    var itemsPublisher: Published<[Tag]>.Publisher { get }
     func fetch()
     func create(_ item: Tag)
     func read(_ item: Tag)

--- a/Targets/UserInterface/Sources/Home/HomeView.swift
+++ b/Targets/UserInterface/Sources/Home/HomeView.swift
@@ -54,31 +54,27 @@ private extension HomeView {
                 ForEach(Array(viewModel.rows.enumerated()), id:\.offset) { columnIndex, rows in
                     HStack(spacing: 10){
                         ForEach(Array(rows.enumerated()), id: \.offset){ rowIndex, row in
-                            Button(action: {
-                                HapticManager.instance.impact(style: .light)
-                                viewModel.selectedTag = row
-                            }, label: {
-                                Text(row.name)
-                            })
-                                .pretendFont(.body2)
-                                .foregroundColor(
-//                                    columnIndex == 0 && rowIndex == 0
-                                    viewModel.selectedTag == row
-                                    ? Color.white
-                                    : .grey4
-                                )
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                                .background(
-                                    ZStack(alignment: .trailing){
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .fill(
-                                                viewModel.selectedTag == row
-                                                ? Color.ticlemoaBlack
-                                                : Color.grey2
-                                            )
-                                    }
-                                )
+                            Button(
+                                action: {
+                                    HapticManager.instance.impact(style: .light)
+                                    viewModel.selectedTag = row
+                                }, label: {
+                                    Text(row.name)
+                                }
+                            )
+                            .pretendFont(.body2)
+                            .foregroundColor(
+                                // columnIndex == 0 && rowIndex == 0
+                                viewModel.tagButtonColor(by: row)
+                            )
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(
+                                ZStack(alignment: .trailing){
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(viewModel.tagBackgroundColor(by: row))
+                                }
+                            )
                         }
                     }
                     .frame(height: 28)
@@ -119,14 +115,6 @@ struct HomeView_Previews: PreviewProvider {
     }
 }
 
-
-// MARK: - Dummy
-struct Tag: Identifiable, Hashable{
-    var id = UUID().uuidString
-    var name: String
-    var size: CGFloat = 0
-}
-
 extension UIScreen{
     static let screenWidth = UIScreen.main.bounds.width
 }
@@ -137,93 +125,5 @@ extension String{
         let attributes = [NSAttributedString.Key.font: font]
         let size = (self as NSString).size(withAttributes: attributes)
         return size.width
-    }
-}
-
-class ContentViewModel: ObservableObject{
-    
-    @Published var rows: [[Tag]] = []
-    @Published var tags: [Tag] = [
-        Tag(name: "전체"),
-        Tag(name: "IOS"),
-        Tag(name: "IOS App Development"),
-        Tag(name: "Swift"),
-        Tag(name: "SwiftUI"),
-        Tag(name: "XCode"),
-        Tag(name: "IOS"),
-        Tag(name: "IOS App Development"),
-        Tag(name: "Swift"),
-        Tag(name: "SwiftUI"),
-        Tag(name: "XCode"),
-        Tag(name: "IOS"),
-        Tag(name: "IOS App Development"),
-        Tag(name: "Swift"),
-        Tag(name: "SwiftUI"),
-        Tag(name: "XCode"),
-        Tag(name: "IOS"),
-        Tag(name: "IOS App Development"),
-        Tag(name: "Swift"),
-        Tag(name: "SwiftUI")
-    ]
-    @Published var tagText = ""
-    
-    @Published var selectedTag: Tag = Tag(name: "전체")
-    
-    init(){
-        getTags()
-    }
-    
-    func getTags(){
-        var rows: [[Tag]] = []
-        var currentRow: [Tag] = []
-        
-        var totalWidth: CGFloat = 0
-        
-        let screenWidth = UIScreen.screenWidth - 10
-        //        let tagSpaceing: CGFloat = 14 /*Leading Padding*/ + 30 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
-        let tagSpaceing: CGFloat = 16 /*Leading Padding*/ + 16 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
-        
-        if !tags.isEmpty{
-            
-            for index in 0..<tags.count{
-                self.tags[index].size = tags[index].name.getSize()
-            }
-            
-            tags.forEach{ tag in
-                
-                totalWidth += (tag.size + tagSpaceing)
-                
-                if totalWidth > screenWidth{
-                    totalWidth = (tag.size + tagSpaceing)
-                    rows.append(currentRow)
-                    currentRow.removeAll()
-                    currentRow.append(tag)
-                }else{
-                    currentRow.append(tag)
-                }
-            }
-            
-            if !currentRow.isEmpty{
-                rows.append(currentRow)
-                currentRow.removeAll()
-            }
-            
-            self.rows = rows
-        } else {
-            self.rows = []
-        }
-        
-    }
-    
-    
-    func addTag(){
-        tags.append(Tag(name: tagText))
-        tagText = ""
-        getTags()
-    }
-    
-    func removeTag(by id: String){
-        tags = tags.filter{ $0.id != id }
-        getTags()
     }
 }

--- a/Targets/UserInterface/Sources/Home/HomeViewModel.swift
+++ b/Targets/UserInterface/Sources/Home/HomeViewModel.swift
@@ -7,42 +7,31 @@
 //
 
 import Foundation
-import Combine
 import Collections
 import UIKit
 
-class HomeViewModel: ObservableObject {
+import SwiftUI
+import DomainInterface
+
+final class HomeViewModel: ObservableObject {
+    
+    @EnvironmentObject var modelContainer: ModelContainer
+    
     @Published var articles: [Article] = []
     @Published var rows: [[Tag]] = []
-    @Published var tags: [Tag] = [
-        Tag(name: "전체"),
-        Tag(name: "빨간라인"),
-        Tag(name: "넘으면"),
-        Tag(name: "내려감"),
-        Tag(name: "디자인"),
-        Tag(name: "MD"),
-        Tag(name: "커리어고민"),
-        Tag(name: "CS/CX"),
-        Tag(name: "인간관계"),
-        Tag(name: "개발"),
-        Tag(name: "마케팅"),
-        Tag(name: "서비스기획"),
-        Tag(name: "조직문화"),
-        Tag(name: "IT/기술"),
-        Tag(name: "취업 이직"),
-        Tag(name: "회사생활"),
-        Tag(name: "라이프스타일"),
-        Tag(name: "경영/젼략")
-    ]
+    @Published var tags: [Tag] = []
     @Published var tagText = ""
     
     @Published var selectedTag: Tag!
-    
-    
+        
     init() {
+        modelContainer.tagModel.itemsPublisher
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$tags)
+        
         // Dummy Data 셋업
         articles = Article.allArticles
-        getTags()
+//        getTags()
         selectedTag = tags.first!
     }
     
@@ -54,58 +43,77 @@ class HomeViewModel: ObservableObject {
         return groupedArticles
     }
     
-    func getTags(){
-        var rows: [[Tag]] = []
-        var currentRow: [Tag] = []
-        
-        var totalWidth: CGFloat = 0
-        
-        let screenWidth = UIScreen.screenWidth - 10
-        //        let tagSpaceing: CGFloat = 14 /*Leading Padding*/ + 30 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
-        let tagSpaceing: CGFloat = 16 /*Leading Padding*/ + 16 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
-        
-        if !tags.isEmpty {
-            
-            for index in 0..<tags.count {
-                self.tags[index].size = tags[index].name.getSize()
-            }
-            
-            tags.forEach { tag in
-                
-                totalWidth += (tag.size + tagSpaceing)
-                
-                if totalWidth > screenWidth{
-                    totalWidth = (tag.size + tagSpaceing)
-                    rows.append(currentRow)
-                    currentRow.removeAll()
-                    currentRow.append(tag)
-                } else {
-                    currentRow.append(tag)
-                }
-            }
-            
-            if !currentRow.isEmpty {
-                rows.append(currentRow)
-                currentRow.removeAll()
-            }
-            
-            self.rows = rows
-        } else {
-            self.rows = []
-        }
-        
+//    func getTags(){
+//        var rows: [[Tag]] = []
+//        var currentRow: [Tag] = []
+//
+//        var totalWidth: CGFloat = 0
+//
+//        let screenWidth = UIScreen.screenWidth - 10
+//        //        let tagSpaceing: CGFloat = 14 /*Leading Padding*/ + 30 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
+//        let tagSpaceing: CGFloat = 16 /*Leading Padding*/ + 16 /*Trailing Padding*/ + 6 + 6 /*Leading & Trailing 6, 6 Spacing*/
+//
+//        if !tags.isEmpty {
+//
+//            for index in 0..<tags.count {
+//                self.tags[index].size = tags[index].name.getSize()
+//            }
+//
+//            tags.forEach { tag in
+//
+//                totalWidth += (tag.size + tagSpaceing)
+//
+//                if totalWidth > screenWidth{
+//                    totalWidth = (tag.size + tagSpaceing)
+//                    rows.append(currentRow)
+//                    currentRow.removeAll()
+//                    currentRow.append(tag)
+//                } else {
+//                    currentRow.append(tag)
+//                }
+//            }
+//
+//            if !currentRow.isEmpty {
+//                rows.append(currentRow)
+//                currentRow.removeAll()
+//            }
+//
+//            self.rows = rows
+//        } else {
+//            self.rows = []
+//        }
+//
+//    }
+}
+
+// MARK: UI Configure
+extension HomeViewModel {
+    
+    func tagButtonColor(by row: Tag) -> Color {
+        self.selectedTag.id == row.id ? Color.white : Color.grey4
     }
     
+    func tagBackgroundColor(by row: Tag) -> Color {
+        self.selectedTag.id == row.id ? Color.ticlemoaBlack : Color.grey2
+    }
+    
+}
+
+extension HomeViewModel {
     
     func addTag(){
-        tags.append(Tag(name: tagText))
+        // modelContainer.tagModel.create()
         tagText = ""
-        getTags()
+//        getTags()
     }
     
-    func removeTag(by id: String){
-        tags = tags.filter{ $0.id != id }
-        getTags()
+    func removeTag(by id: UUID){
+        guard let removingItem = tags.first(where: { $0.id == id }) else {
+            return
+        }
+        modelContainer.tagModel.remove(removingItem)
+//        getTags()
     }
+    
 }
 


### PR DESCRIPTION
## 📌 배경

open #108 

## 내용
1. Model 에서 데이터 바인딩
   Published<[Type]>.Publisher 개념을 이용해서 데이터 바인딩 구조로 변경했습니다.  
   [관련자료 블로그](https://swiftsenpai.com/swift/define-protocol-with-published-property-wrapper/)
2. ViewModel 내부에 Model 접근 방식 예제를 적용했습니다.
3. ViewModel 에서 처리되면 좋을 Color 관련 메서드를 생성했습니다.

Todos   
   size 를 적용
   ViewModel 내부에 `struct TagLayout` 같은 연산 프로퍼티를 두고   
   tags 의 데이터를 미러링 하도록 하는 형태를 구현하면 어떨까 하는 아이디어 입니다.

우선은 현재 View-ViewModel-ModelContainer(Model) 접근 형태에 중점을 두고 작성했습니다.

## 테스트 방법 
develop 브런치가 아직 에러가 살아있습니다.
`UserInteface/Home/Network/GetArticle/Article.swift`
타입 명과 파일 명을 `ResponseArticle` (임시) 바꿔주시고

빌드시 발생하는 View 부분 ViewModifier 에러 부분 주석처리 해주시면 빌드가 가능합니다.