### PR TITLE
[Refactor] KakaoLogin Migration & API 리팩토링

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -103,7 +103,6 @@ let userInterface = makeModule(
     .userInterface,
     dependencies: [
         .target(name: Ticlemoa.domainInterface.name),
-        .external(name: "KakaoSDK"),
         .external(name: "Collections")
     ],
     hasTest: true
@@ -117,7 +116,8 @@ let domain = makeModule(
     .domain,
     dependencies: [
         .target(name: Ticlemoa.api.name),
-        .target(name: Ticlemoa.domainInterface.name)
+        .target(name: Ticlemoa.domainInterface.name),
+        .external(name: "KakaoSDK")
     ],
     hasTest: true
 )

--- a/Targets/API/Sources/APIDetails.swift
+++ b/Targets/API/Sources/APIDetails.swift
@@ -9,8 +9,7 @@
 import Foundation
 
 public protocol APIDetails {
-    func kakaoLogin(by request: KakaoLoginRequest) async -> Data?
-    func uploadArticle(by request: UploadArticleRequest) async -> Data?
+    func request(by request: URLRequestMakable) async throws -> Data
 }
 
 enum HTTPMethod: String {
@@ -34,47 +33,22 @@ public struct TiclemoaAPI {
     
 }
 
-// MARK: Login
 extension TiclemoaAPI: APIDetails {
     
-    public func kakaoLogin(by request: KakaoLoginRequest) async -> Data? {
+    public func request(by request: URLRequestMakable) async throws -> Data {
         let urlRequest = request.makeURLRequest(by: baseURL)
         
         do {
             let (data, response) = try await URLSession.shared.data(for: urlRequest)
-            let httpResponse = response as? HTTPURLResponse
-            print("DEBUG: ", httpResponse!)
-            
-            guard (response as? HTTPURLResponse)?.statusCode == 200 || (response as? HTTPURLResponse)?.statusCode == 201 else {
-                return nil
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 || httpResponse.statusCode == 201
+            else {
+                throw NetworkError.inValidURLRequest
             }
-            print("DEUBG: \(response.description)")
+            
             return data
         } catch {
-            return nil
-        }
-    }
-    
-}
-
-// MARK: Article
-extension TiclemoaAPI {
-    
-    public func uploadArticle(by request: UploadArticleRequest) async -> Data? {
-        let urlRequest = request.makeURLRequest(by: baseURL)
-        
-        do {
-            let (data, response) = try await URLSession.shared.data(for: urlRequest)
-            let httpResponse = response as? HTTPURLResponse
-            print("DEBUG: ", httpResponse!)
-            
-            guard (response as? HTTPURLResponse)?.statusCode == 200 || (response as? HTTPURLResponse)?.statusCode == 201 else {
-                return nil
-            }
-            print("DEUBG: \(response.description)")
-            return data
-        } catch {
-            return nil
+            throw NetworkError.inValidURLRequest
         }
     }
     

--- a/Targets/API/Sources/NetworkError.swift
+++ b/Targets/API/Sources/NetworkError.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum NetworkError: String, Error {
     case inValidURLString
+    case inValidURLRequest
     case parseUrlFail
     case notFound
     case validationError
@@ -18,18 +19,13 @@ enum NetworkError: String, Error {
     
     var errorDescription: String? {
         switch self {
-        case .inValidURLString:
-            return self.rawValue
-        case .parseUrlFail:
-            return "Cannot initial URL object."
-        case .notFound:
-            return "Not Found"
-        case .validationError:
-            return "Validation Errors"
-        case .serverError:
-            return "Internal Server Error"
-        case .defaultError:
-            return "Something went wrong."
+            case .inValidURLString:     return self.rawValue
+            case .inValidURLRequest:    return self.rawValue
+            case .parseUrlFail:         return "Cannot initial URL object."
+            case .notFound:             return "Not Found"
+            case .validationError:      return "Validation Errors"
+            case .serverError:          return "Internal Server Error"
+            case .defaultError:         return "Something went wrong."
         }
     }
 }

--- a/Targets/API/Sources/Request/KakaoLoginRequest.swift
+++ b/Targets/API/Sources/Request/KakaoLoginRequest.swift
@@ -17,8 +17,12 @@ public struct KakaoLoginRequest: Encodable {
         self.accessToken = accessToken
         self.vendor = vendor
     }
+
+}
+
+extension KakaoLoginRequest: URLRequestMakable {
     
-    func makeURLRequest(by baseURL: URL) -> URLRequest {
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
         var request = URLRequest(
             url: baseURL,
             cachePolicy: .reloadIgnoringLocalCacheData,

--- a/Targets/API/Sources/Request/KakaoLoginRequest.swift
+++ b/Targets/API/Sources/Request/KakaoLoginRequest.swift
@@ -29,12 +29,8 @@ extension KakaoLoginRequest: URLRequestMakable {
         )
         request.httpMethod = HTTPMethod.post.rawValue
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(self)
         
-        let json: [String: Any] = [
-            "accessToken": "\(accessToken)",
-            "vendor": "\(vendor)"
-        ]
-        request.httpBody = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
         return request
     }
     

--- a/Targets/API/Sources/Request/KakaoLoginRequest.swift
+++ b/Targets/API/Sources/Request/KakaoLoginRequest.swift
@@ -11,11 +11,10 @@ import Foundation
 public struct KakaoLoginRequest: Encodable {
     /// KakaoTalk SDK 에서 발급해주는 "oauthToken"
     let accessToken: String
-    let vendor: String
+    let vendor: String = "kakao"
     
-    public init(accessToken: String, vendor: String) {
+    public init(accessToken: String) {
         self.accessToken = accessToken
-        self.vendor = vendor
     }
 
 }

--- a/Targets/API/Sources/Request/URLRequestMakable.swift
+++ b/Targets/API/Sources/Request/URLRequestMakable.swift
@@ -1,0 +1,13 @@
+//
+//  URLRequestMakable.swift
+//  API
+//
+//  Created by 김용우 on 2023/01/04.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public protocol URLRequestMakable {
+    func makeURLRequest(by baseURL: URL) -> URLRequest
+}

--- a/Targets/API/Sources/Request/UploadArticleRequest.swift
+++ b/Targets/API/Sources/Request/UploadArticleRequest.swift
@@ -35,7 +35,11 @@ public struct UploadArticleRequest: Encodable {
         self.tagIds = tagIds
     }
     
-    func makeURLRequest(by baseURL: URL) -> URLRequest {
+}
+
+extension UploadArticleRequest: URLRequestMakable {
+    
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
         var request = URLRequest(
             url: baseURL,
             cachePolicy: .reloadIgnoringLocalCacheData,

--- a/Targets/API/Sources/Request/UploadArticleRequest.swift
+++ b/Targets/API/Sources/Request/UploadArticleRequest.swift
@@ -47,17 +47,9 @@ extension UploadArticleRequest: URLRequestMakable {
         )
         request.httpMethod = HTTPMethod.post.rawValue
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
-        let json: [String: Any] = [
-            "content"   : content,
-            "userId"    : userId,
-            "title"     : title,
-            "url"       : url,
-            "isPublic"  : isPublic,
-            "tagIds"    : tagIds,
-        ]
         request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+        request.httpBody = try? JSONEncoder().encode(self)
+        
         return request
     }
     

--- a/Targets/Domain/Sources/Entity/LoginUserData.swift
+++ b/Targets/Domain/Sources/Entity/LoginUserData.swift
@@ -1,13 +1,16 @@
 //
-//  User.swift
+//  LoginUserData.swift
 //  Domain
 //
 //  Created by 김용우 on 2022/12/16.
 //  Copyright © 2022 nyongnyong. All rights reserved.
 //
 
+import DomainInterface
+
 import Foundation
 
-public struct User {
+struct LoginUserData: LoginUser {
     let nickName: String
+    let accessToken: String?
 }

--- a/Targets/Domain/Sources/Model/ArticleModel.swift
+++ b/Targets/Domain/Sources/Model/ArticleModel.swift
@@ -11,6 +11,21 @@ import DomainInterface
 
 import Foundation
 
+extension Article {
+    
+    func uploadArticleRequest(with accessToken: String) -> UploadArticleRequest {
+        .init(
+            accessToken: accessToken,
+            content: self.content,
+            title: self.title,
+            url: self.url,
+            isPublic: self.isPublic,
+            tagIds: self.tagIds
+        )
+    }
+    
+}
+
 public final class ArticleModel: ArticleModelProtocol {
     
     @Published public var items: [Article] = []
@@ -37,19 +52,9 @@ extension ArticleModel {
     }
     
     public func update(_ item: Article) async {
-        let request = UploadArticleRequest(
-            accessToken: "",
-            content: item.content,
-            title: item.title,
-            url: item.url,
-            isPublic: item.isPublic,
-            tagIds: item.tagIds
-        )
-        guard let data = await api.uploadArticle(by: request) else {
-            return
-        }
-        
+        let uploadArticleRequest = item.uploadArticleRequest(with: "accessToken") // TODO: 전달방법 고민 필요 UserDefault?
         do {
+            let data = try await api.request(by: uploadArticleRequest)
             let response = try JSONDecoder().decode(UploadArticleResponse.self, from: data)
         } catch {
             print(error.localizedDescription)

--- a/Targets/Domain/Sources/Model/LoginModel.swift
+++ b/Targets/Domain/Sources/Model/LoginModel.swift
@@ -70,9 +70,18 @@ extension LoginModel {
             }
         }
     }
-        self.userData = response.updateAccessToken(from: userData)
-        
-        return true
+    
+    private func requestKakaoLogin(_ accessToken: String) async -> Bool {
+        let kakaoLoginRequest = KakaoLoginRequest(accessToken: accessToken)
+        do {
+            let data = try await api.request(by: kakaoLoginRequest)
+            let response = try JSONDecoder().decode(KakaoLoginResponse.self, from: data)
+            self.userData = response.updateAccessToken(from: userData)
+            return true
+        } catch {
+            print(error.localizedDescription)
+            return false
+        }
     }
     
 }

--- a/Targets/Domain/Sources/Model/LoginModel.swift
+++ b/Targets/Domain/Sources/Model/LoginModel.swift
@@ -11,14 +11,22 @@ import Foundation
 import API
 import DomainInterface
 
+extension KakaoLoginResponse {
+    func updateAccessToken(from userData: LoginUser) -> LoginUserData {
+        .init(nickName: userData.nickName, accessToken: self.accessToken)
+    }
+}
+
 public final class LoginModel: LoginModelProtocol {
     
-    public var accessTokenPublisher: Published<String?>.Publisher { $accessToken }
+    public var userDataPublisher: Published<LoginUser>.Publisher { $userData }
     
-    @Published private var accessToken: String?
+    @Published private var userData: LoginUser
     private let api: APIDetails = TiclemoaAPI()
     
-    public init() { }
+    public init() {
+        self.userData = LoginUserData(nickName: "", accessToken: nil) // 초기값 추가 UserDefault?
+    }
     
 }
 
@@ -35,7 +43,7 @@ extension LoginModel {
         guard let response = try? JSONDecoder().decode(KakaoLoginResponse.self, from: data) else {
             return false
         }
-        self.accessToken = response.accessToken
+        self.userData = response.updateAccessToken(from: userData)
         
         return true
     }

--- a/Targets/DomainInterface/Sources/Entity/LoginUser.swift
+++ b/Targets/DomainInterface/Sources/Entity/LoginUser.swift
@@ -1,0 +1,14 @@
+//
+//  LoginUser.swift
+//  DomainInterface
+//
+//  Created by 김용우 on 2023/01/04.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoginUser {
+    var nickName: String { get }
+    var accessToken: String? { get }
+}

--- a/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public protocol LoginModelProtocol {
-    var accessTokenPublisher: Published<String?>.Publisher { get }
+    var userDataPublisher: Published<LoginUser>.Publisher { get }
     func requestKakaoLogin(_ accessToken: String) async -> Bool
 }

--- a/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 
 public protocol LoginModelProtocol {
     var userDataPublisher: Published<LoginUser>.Publisher { get }
-    func requestKakaoLogin(_ accessToken: String) async -> Bool
+    func checkKakaoLogin() async -> Bool
 }

--- a/Targets/UserInterface/Sources/Home/HomeArticle/Article.swift
+++ b/Targets/UserInterface/Sources/Home/HomeArticle/Article.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Collections
-import UIKit
+//import UIKit
 import SwiftUI
 
 typealias ArticleGroup = OrderedDictionary<String, [Article]>

--- a/Targets/UserInterface/Sources/Login/LoginViewModel.swift
+++ b/Targets/UserInterface/Sources/Login/LoginViewModel.swift
@@ -9,39 +9,14 @@
 import Foundation
 import SwiftUI
 
-import KakaoSDKUser
-import KakaoSDKAuth
-import KakaoSDKCommon
-
-
 class LoginViewModel: ObservableObject {
     
     @EnvironmentObject var modelContainer: ModelContainer
     
     public func kakaoButtonDidTap() async throws -> Bool {
-        var kakaoLoginerror: Error?
-        let kakaoToken = await withCheckedContinuation { continuation in
-            // 앱 로그인
-            if (UserApi.isKakaoTalkLoginAvailable()) {
-                UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
-                    kakaoLoginerror = error
-                    continuation.resume(returning: oauthToken)
-                }
-                
-                // 웹 로그인
-            } else {
-                UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
-                    kakaoLoginerror = error
-                    continuation.resume(returning: oauthToken)
-                }
-            }
-        }
-        
-        guard kakaoLoginerror == nil else { return false }
-        guard let accessToken = kakaoToken?.accessToken else { return false }
-        
-        return await modelContainer.loginModel.requestKakaoLogin(accessToken)
+        await modelContainer.loginModel.checkKakaoLogin()
     }
+    
 }
 
 


### PR DESCRIPTION
## 📌 배경

closed #111 
closed #112 같은 내용입니다.

## 내용
#111 이어서 체이닝으로 PR Open 했습니다. 몇가지 변경사항은 해당 PR에 변경 적용했습니다.

1. 사용자 로그인 정보 담은 개체 생성
   > `LoginUser` / 네이밍 탈락 사유 User - 카카오 겹침, UserInfo - System 겹침   
   > `accessToken` 과 별개로 운용해야할지 고민중입니다. (UserDefault)   
   > 로그인 기능 경험자 도와주세요! ㅠㅠ
2. KakaoLogin 모듈 변경
   > UserInterface -> Domain     
   > App 과 Domain 모듈에만 접근 가능합니다.
3. API 메서드를 단순화 했습니다.
   > enum 과 case 형태에서 Request 용 개체와 해당 개체를 URLRequest 로 만들어 주는 형태로 변경
4. JSONEncoder 이용한 리팩토링 
   > [요셉님이 주신 제안사항](https://github.com/depromeet/ticlemoa-iOS/pull/111#discussion_r1061085835) 적용했습니다.