### PR TITLE
[Refactor] ModelContainer 의존성 주입 시점 변경

### DIFF
--- a/Targets/Ticlemoa/Sources/TiclemoaApp.swift
+++ b/Targets/Ticlemoa/Sources/TiclemoaApp.swift
@@ -16,7 +16,7 @@ import KakaoSDKCommon
 @main
 struct TiclemoaApp: App {
     
-    private let modelContainer = ModelContainer(
+    @StateObject var modelContainer = ModelContainer(
         articleModel: ArticleModel(),
         tagModel: TagModel(),
         loginModel: LoginModel()

--- a/Targets/UserInterface/Sources/ContentView.swift
+++ b/Targets/UserInterface/Sources/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 public struct ContentView: View {
     @State private var isLoggedIn: Bool = false // MARK: AppStore? UserDefault?
+    @EnvironmentObject var modelContainer: ModelContainer
     
     public init() { }
     
@@ -19,7 +20,12 @@ public struct ContentView: View {
                 MainTabView()
                     .transition(.scale)
             } else {
-                LoginView(isLoggedIn: $isLoggedIn)
+                LoginView(
+                    viewModel: LoginViewModel(
+                        modelContainer: modelContainer
+                    ),
+                    isLoggedIn: $isLoggedIn
+                )
                     .transition(.scale)
                 
             }

--- a/Targets/UserInterface/Sources/Login/LoginView.swift
+++ b/Targets/UserInterface/Sources/Login/LoginView.swift
@@ -13,7 +13,7 @@ import KakaoSDKCommon
 import AuthenticationServices
 
 struct LoginView: View {
-    @StateObject private var viewModel = LoginViewModel()
+    @ObservedObject var viewModel: LoginViewModel
     @Binding var isLoggedIn: Bool
     @Environment(\.window) var window: UIWindow?
     @State var appleSignInDelegates: SignInWithAppleDelegates! = nil
@@ -141,10 +141,26 @@ private extension LoginView {
     }
 }
 
-struct LoginView_Previews: PreviewProvider {
-    @State static  var isLoggedIn: Bool = false
-    
-    static var previews: some View {
-        LoginView(isLoggedIn: $isLoggedIn)
-    }
-}
+//#if DEBUG
+//import Domain
+//
+//struct LoginView_Previews: PreviewProvider {
+//    static var modelContainer = ModelContainer(
+//        articleModel: ArticleModel(),
+//        tagModel: TagModel(),
+//        loginModel: LoginModel()
+//    )
+//    @State static  var isLoggedIn: Bool = false
+//
+//    static var previews: some View {
+//        LoginView(
+//            viewModel:
+//                LoginViewModel(
+//                modelContainer: modelContainer
+//                ),
+//            isLoggedIn: $isLoggedIn
+//        )
+//    }
+//}
+//
+//#endif

--- a/Targets/UserInterface/Sources/Login/LoginViewModel.swift
+++ b/Targets/UserInterface/Sources/Login/LoginViewModel.swift
@@ -11,7 +11,11 @@ import SwiftUI
 
 class LoginViewModel: ObservableObject {
     
-    @EnvironmentObject var modelContainer: ModelContainer
+    @ObservedObject var modelContainer: ModelContainer
+    
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
     
     public func kakaoButtonDidTap() async throws -> Bool {
         await modelContainer.loginModel.checkKakaoLogin()


### PR DESCRIPTION
- 기존: EnvironmentObject 로 ViewModel 에 의존성 주입
- 현제: EnvironmentObject 를 통해 View 생성시점에 초기화하여 ViewModel 에 생성자 의존성 주입으로 주입 (ContentView 에서 생성하고 LoginView 생성 시점에 ModelContainer 주입)

## 📌 배경

- 23.01.04 iOS 팀 회의하면서 논의했던 사항 중 "EnvironmentObject" 를 통한 ModelContainer 주입 관련 내용입니다.
- 생성자 의존성주입과 싱글톤을 통한 의존성 주입이 있었고, 그 중 생성자 의존성 주입에 해당합니다.

## 내용

1. 최초 `ModelContainer` 생성 시, StateObject 로 생성합니다.
2. `ContentView.swift` 에서 @EnvironmentObject 를 생성하고, 동시에 LoginViewModel 에 `ModelContainer` 를 주입합니다.
3. `LoginViewModel` 에서는 @ObservedObject 로 접근합니다.