### PR TITLE
[Refactor] Font Modifier 

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -148,6 +148,17 @@ let infoPlist: InfoPlist = .extendingDefault(with: [
         "LSApplicationQueriesSchemes" : [
             "kakaokompassauth",
             "kakaolink"
+        ],
+        "UIAppFonts": [
+            "Pretendard-Black.otf",
+            "Pretendard-Bold.otf",
+            "Pretendard-ExtraBold.otf",
+            "Pretendard-ExtraLight.otf",
+            "Pretendard-Light.otf",
+            "Pretendard-Medium.otf",
+            "Pretendard-Regular.otf",
+            "Pretendard-SemiBold.otf",
+            "Pretendard-Thin.otf"
         ]
     ]
 )

--- a/Targets/UserInterface/Sources/Login/LoginView.swift
+++ b/Targets/UserInterface/Sources/Login/LoginView.swift
@@ -51,10 +51,20 @@ private extension LoginView {
     var headerTitles: some View {
         Group {
             Text("반갑습니다!\n티클모아에서 모아봐요")
-                .pretendFont(.title3)
+                .customFont(
+                    weight: 700,
+                    size: 24,
+                    lineHeight: 28.8,
+                    style: .bold
+                )
             
             Text("티클모아에서는 나의 아티클을 모으고,\n 다른 사람의 아티클도 모아볼 수 있어요 📝")
-                .pretendFont(.body1)
+                .customFont(
+                    weight: 500,
+                    size: 14,
+                    lineHeight: 21,
+                    style: .medium
+                )
         }
         .multilineTextAlignment(.center)
     }
@@ -128,7 +138,12 @@ private extension LoginView {
                     .cornerRadius(12)
                 VStack {
                     Text(text)
-                        .pretendFont(.subhead3)
+                        .customFont(
+                            weight: 600,
+                            size: 15,
+                            lineHeight: 24,
+                            style: .semiBold
+                        )
                         .foregroundColor(.black)
                 }
             }

--- a/Targets/UserInterface/Sources/Utils/Fonts/Font+Extension.swift
+++ b/Targets/UserInterface/Sources/Utils/Fonts/Font+Extension.swift
@@ -16,6 +16,14 @@ extension UIFont {
     ) -> UIFont {
         return UIFont(name: "Pretendard-\(weight.rawValue)", size: size) ?? UIFont.boldSystemFont(ofSize: 50)
     }
+    
+    static func setupCustomFont(
+        weight: CGFloat,
+        size: CGFloat = 12,
+        style: PretendardFontWeight
+    ) -> UIFont {
+        return UIFont(name: "Pretendard-\(style.rawValue)", size: size) ?? UIFont.boldSystemFont(ofSize: 50)
+    }
 }
 
 
@@ -122,15 +130,36 @@ struct FontWithLineHeight: ViewModifier {
 
 extension View {
     func pretendFont(
-        _ font: FontSystem
+            _ font: FontSystem
+        ) -> some View {
+            let size = font.size
+            let weight = font.weight
+            let lineHeight = font.lineHeight
+            
+            let font: UIFont = UIFont.pretend(
+                size: size,
+                weight: weight
+            )
+            
+            return ModifiedContent(
+                content: self,
+                modifier: FontWithLineHeight(
+                    font: font,
+                    lineHeight: lineHeight)
+            )
+        }
+    
+    func customFont(
+        weight: CGFloat,
+        size: CGFloat,
+        lineHeight: CGFloat,
+        style: PretendardFontWeight = .medium
     ) -> some View {
-        let size = font.size
-        let weight = font.weight
-        let lineHeight = font.lineHeight
         
-        let font: UIFont = UIFont.pretend(
+        let font: UIFont = UIFont.setupCustomFont(
+            weight: weight,
             size: size,
-            weight: weight
+            style: style
         )
         
         return ModifiedContent(
@@ -144,17 +173,34 @@ extension View {
 
 struct FontTestView: View {
     var body: some View {
-        VStack {
-            Spacer()
-            Text("Title3")
-                .pretendFont(.title3)
+        VStack() {
             
-            Text("Title2")
-                .pretendFont(.title1)
+            Text("반갑습니다!\n티끌모아에서 모아봐요")
+                .customFont(
+                    weight: 700,
+                    size: 16,
+                    lineHeight: 28, style: .bold
+                ).setupBackground()
             
-            Text("Title1")
-                .pretendFont(.body1)
-            Spacer()
+            Text("전체")
+                .customFont(
+                    weight: 700,
+                    size: 14,
+                    lineHeight: 21,
+                    style: .bold
+                )
+                .foregroundColor(Color.white)
+                .background(Color.black)
+            
+            Text("아티클 제목은 최대 2줄로 적어주세요.\n컨테이너를 넘을 경우...으로")
+                .customFont(
+                    weight: 600,
+                    size: 16,
+                    lineHeight: 24,
+                    style: .semiBold
+                )
+                .setupBackground()
+            
         }
     }
 }


### PR DESCRIPTION
## 📌 배경
- Figma Typography 에 있는 스타일로 변경 필요성이 있어서 개선합니다.

## 내용
- 기존 `pretend` Modifier 대신 `customFont` 로 사용할 수 있도록 Modifier 추가했습니다.
(기존 `pretend` Modifier 는 코드 리뷰 후, 나머지 UI 적용 시점에 제거예정)
- info.plist 에 `UIAppFonts` 속성 추가했습니다.
- 예시로, LoginView 의 Header Text 에 적용했습니다.

## 테스트 방법
- 해당 폰트 적용하기 위해서는 Xcode 에는 보이지 않으나, 파일은 있는 Font 파일을 추가해야합니다.
경로 : UserInterface > Utils > Fonts 
"Pretendard-Black.otf"
"Pretendard-Bold.otf"
"Pretendard-ExtraBold.otf"
"Pretendard-ExtraLight.otf"
"Pretendard-Light.otf"
"Pretendard-Medium.otf"
"Pretendard-Regular.otf"
"Pretendard-SemiBold.otf"
"Pretendard-Thin.otf"

1. add file to "Ticlemoa" 클릭하여, Font 파일 추가합니다.
![image](https://user-images.githubusercontent.com/65879950/210876819-806d998d-6b66-4aef-9b5a-23205a8fc5a2.png)

2. Font 파일을 모두 선택합니다.
![image](https://user-images.githubusercontent.com/65879950/210876917-1f564c7b-14c6-4aa1-816e-4ec8c87143d0.png)

3. 하단에 "Add to targets" 항목에 "Ticlemoa" 를 Target 으로 지정합니다
![image](https://user-images.githubusercontent.com/65879950/210877070-424481c2-e0e2-4916-b35c-f98980b57394.png)

4. "Add" 버튼을 누릅니다.

코드 사용 예시 다음과 같습니다.

- Figma
<img width="168" alt="image" src="https://user-images.githubusercontent.com/65879950/210877743-c5fb3f50-847b-4d2a-bc77-f759225a2fbe.png">

- Xcode
```swift
Text("티클모아에서는 나의 아티클을 모으고,\n 다른 사람의 아티클도 모아볼 수 있어요 📝")
                .customFont(
                    weight: 500,
                    size: 14,
                    lineHeight: 21,
                    style: .medium
                )
```


## 스크린샷 

<img width="518" alt="image" src="https://user-images.githubusercontent.com/65879950/210877245-f2b972bd-3760-420e-a357-af6370296fac.png">

좌측 : 시뮬레이터
우측 : 피그마