### PR TITLE
[Fix] KakaoSDK 모듈 이동으로 발생한 에러처리

### DIFF
--- a/Targets/Domain/Sources/Model/LoginModel.swift
+++ b/Targets/Domain/Sources/Model/LoginModel.swift
@@ -36,6 +36,14 @@ public final class LoginModel: LoginModelProtocol {
 
 extension LoginModel {
     
+    public func isKakaoTalkLoginUrl(_ url: URL) -> Bool {
+        AuthApi.isKakaoTalkLoginUrl(url)
+    }
+    
+    public func authController(url: URL) -> Bool {
+        AuthController.handleOpenUrl(url: url)
+    }
+    
     public func checkKakaoLogin() async -> Bool {
         switch await kakaoAccessToken() {
             case .success(let token):

--- a/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
@@ -11,4 +11,6 @@ import Foundation
 public protocol LoginModelProtocol {
     var userDataPublisher: Published<LoginUser>.Publisher { get }
     func checkKakaoLogin() async -> Bool
+    func isKakaoTalkLoginUrl(_ url: URL) -> Bool
+    func authController(url: URL) -> Bool
 }

--- a/Targets/UserInterface/Sources/Login/LoginView.swift
+++ b/Targets/UserInterface/Sources/Login/LoginView.swift
@@ -7,9 +7,6 @@
 //
 
 import SwiftUI
-import KakaoSDKUser
-import KakaoSDKAuth
-import KakaoSDKCommon
 import AuthenticationServices
 
 struct LoginView: View {
@@ -21,8 +18,8 @@ struct LoginView: View {
     var body: some View {
         mainBody
             .onOpenURL { url in
-                if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                    _ = AuthController.handleOpenUrl(url: url)
+                if viewModel.isKakaoTalkLogin(url) {
+                    _ = viewModel.authControllerHandleOpen(url: url)
                 }
             }
             .setupBackground()

--- a/Targets/UserInterface/Sources/Login/LoginViewModel.swift
+++ b/Targets/UserInterface/Sources/Login/LoginViewModel.swift
@@ -19,6 +19,18 @@ class LoginViewModel: ObservableObject {
     
 }
 
+// MARK: Auth
+extension LoginViewModel {
+    
+    func isKakaoTalkLogin(_ url: URL) -> Bool {
+        modelContainer.loginModel.isKakaoTalkLoginUrl(url)
+    }
+    
+    func authControllerHandleOpen(url: URL) -> Bool {
+        modelContainer.loginModel.authController(url: url)
+    }
+    
+}
 
 
 


### PR DESCRIPTION
## 📌 배경

close #121 

## 내용
- UserInterface 모듈에서 KakaoSDK 관련 코드 제거
- LoginDomain, LoginDomainProtocol 및 LoginViewModel  에 관련 코드 작성

## 테스트 방법
- 화면 상단에 타겟을 변경해서 빌드
![image](https://user-images.githubusercontent.com/24707229/210923633-2568120c-5fc6-4405-8111-3d4804e19086.png)