### PR TITLE
[Feature] Tag 서버 통신 API CRUD 추가

### DIFF
--- a/Targets/API/Sources/Request/Tag/CreateTagRequest.swift
+++ b/Targets/API/Sources/Request/Tag/CreateTagRequest.swift
@@ -1,0 +1,46 @@
+//
+//  CreateTagRequest.swift
+//  API
+//
+//  Created by Joseph Cha on 2023/01/07.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public struct CreateTagRequest {
+    
+    let accessToken: String
+    let body: Body
+    
+    public struct Body: Encodable {
+        let tagName: String
+        
+        public init(tagName: String) {
+            self.tagName = tagName
+        }
+    }
+    
+    public init(accessToken: String, body: Body) {
+        self.accessToken = accessToken
+        self.body = body
+    }
+}
+
+extension CreateTagRequest: URLRequestMakable {
+    
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("/tag"),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10
+        )
+        
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONEncoder().encode(self.body)
+        
+        return request
+    }
+}

--- a/Targets/API/Sources/Request/Tag/DeleteTagRequest.swift
+++ b/Targets/API/Sources/Request/Tag/DeleteTagRequest.swift
@@ -1,0 +1,42 @@
+//
+//  DeleteTagRequest.swift
+//  API
+//
+//  Created by Joseph Cha on 2023/01/07.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public struct DeleteTagRequest: Encodable {
+    
+    let accessToken: String
+    let tagId: Int
+    
+    public init(accessToken: String, tagId: Int) {
+        self.accessToken = accessToken
+        self.tagId = tagId
+    }
+}
+
+extension DeleteTagRequest: URLRequestMakable {
+    
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
+        let urlComponents = URLComponents(
+            url: baseURL.appendingPathExtension("/tag/\(tagId)"),
+            resolvingAgainstBaseURL: false
+        )
+        
+        var request = URLRequest(
+            url: urlComponents?.url ?? baseURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10
+        )
+        request.httpMethod = HTTPMethod.delete.rawValue
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        return request
+    }
+}
+

--- a/Targets/API/Sources/Request/Tag/ReadTagRequest.swift
+++ b/Targets/API/Sources/Request/Tag/ReadTagRequest.swift
@@ -1,0 +1,40 @@
+//
+//  ReadTagRequest.swift
+//  API
+//
+//  Created by Joseph Cha on 2023/01/07.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public struct ReadTagRequest {
+    
+    let accessToken: String
+    let page: Int
+    let take: Int
+    
+    public init(accessToken: String, page: Int, take: Int) {
+        self.accessToken = accessToken
+        self.page = page
+        self.take = take
+    }
+}
+
+extension ReadTagRequest: URLRequestMakable {
+    
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("/tag").appendingPathComponent("/\(page)")
+                .appendingPathComponent("/\(take)"),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10
+        )
+        
+        request.httpMethod = HTTPMethod.get.rawValue
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        return request
+    }
+}

--- a/Targets/API/Sources/Request/Tag/UpdateTagRequest.swift
+++ b/Targets/API/Sources/Request/Tag/UpdateTagRequest.swift
@@ -1,0 +1,48 @@
+//
+//  UpdateTagRequest.swift
+//  DomainInterface
+//
+//  Created by Joseph Cha on 2023/01/07.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public struct UpdateTagRequest {
+    
+    let accessToken: String
+    let tagId: Int
+    let body: Body
+    
+    public init(accessToken: String, tagId: Int, body: Body) {
+        self.accessToken = accessToken
+        self.tagId = tagId
+        self.body = body
+    }
+    
+    public struct Body: Encodable {
+        let tagName: String
+        
+        public init(tagName: String) {
+            self.tagName = tagName
+        }
+    }
+}
+
+extension UpdateTagRequest: URLRequestMakable {
+    
+    public func makeURLRequest(by baseURL: URL) -> URLRequest {
+        
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("/tag").appendingPathComponent("\(tagId)"),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10
+        )
+        request.httpMethod = HTTPMethod.put.rawValue
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONEncoder().encode(self.body)
+        
+        return request
+    }
+}

--- a/Targets/API/Sources/Response/Login/KakaoLoginResponse.swift
+++ b/Targets/API/Sources/Response/Login/KakaoLoginResponse.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct KakaoLoginResponse: Decodable {
-    let accessToken: String
-    let userId: Int
+    public let accessToken: String
+    public let userId: Int
     
     init(accessToken: String, userId: Int) {
         self.accessToken = accessToken

--- a/Targets/API/Sources/Response/Tag/ReadTagResponse.swift
+++ b/Targets/API/Sources/Response/Tag/ReadTagResponse.swift
@@ -1,0 +1,19 @@
+//
+//  ReadTagResponse.swift
+//  API
+//
+//  Created by Joseph Cha on 2023/01/07.
+//  Copyright © 2023 nyongnyong. All rights reserved.
+//
+
+import Foundation
+
+public struct ReadTagResponse: Decodable {
+    public let tags: [ReadTag]
+    
+    public struct ReadTag: Decodable {
+        public let id: Int
+        public let userId: Int
+        public let tagName: String
+    }
+}

--- a/Targets/API/Tests/APITests.swift
+++ b/Targets/API/Tests/APITests.swift
@@ -153,7 +153,13 @@ extension APITests {
             XCTAssertTrue(false)
         }
     }
-    
+}
+
+/* MARK: - Tag Request / Response
+ tagId는 test_readTag를 통해 확인 후 직접 기입
+ */
+
+extension APITests {
     func test_createTag() async {
         // given
         let newItem = CreateTagRequest.Body(tagName: "차요셉 태그")
@@ -220,13 +226,3 @@ extension APITests {
         
     }
 }
-
-// MARK: - Article Request / Response
-/*
-    
- */
-
-extension APITests {
-    
-}
-

--- a/Targets/API/Tests/APITests.swift
+++ b/Targets/API/Tests/APITests.swift
@@ -154,6 +154,71 @@ extension APITests {
         }
     }
     
+    func test_createTag() async {
+        // given
+        let newItem = CreateTagRequest.Body(tagName: "차요셉 태그")
+        let request = CreateTagRequest(accessToken: accessToken, body: newItem)
+        
+        // when
+        let result = await self.sut.request(by: request)
+        if case .success(let data) = result {
+        // then
+            XCTAssertNotNil(data)
+        } else {
+            XCTAssertTrue(false)
+        }
+
+    }
+    
+    func test_readTag() async {
+        // given
+        let request = ReadTagRequest(accessToken: accessToken, page: 1, take: 1)
+        
+        // when
+        let result = await self.sut.request(by: request)
+        if case .success(let data) = result {
+            let response = try? JSONDecoder().decode(ReadTagResponse.self, from: data)
+
+        // then
+            XCTAssertNotNil(data)
+            XCTAssertNotNil(response)
+        } else {
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func test_updateTag() async {
+        // given
+        let newItem = UpdateTagRequest.Body(tagName: "차요셉 태그")
+        let request = UpdateTagRequest(accessToken: accessToken, tagId: 1, body: newItem) // TODO: tagId는 test_readTag를 통해 확인 후 직접 기입
+        
+        // when
+        let result = await self.sut.request(by: request)
+        if case .success(let data) = result {
+
+        // then
+            XCTAssertNotNil(data)
+        } else {
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func test_deleteTag() async {
+        // given
+        let request = DeleteTagRequest(accessToken: accessToken, tagId: 1) // TODO: tagId는 test_readTag를 통해 확인 후 직접 기입
+        
+        // when
+        let result = await self.sut.request(by: request)
+        var success: Bool
+        switch result {
+            case .success(_): success = true
+            case .failure(_): success = false
+        }
+        
+        // then
+        XCTAssertTrue(success)
+        
+    }
 }
 
 // MARK: - Article Request / Response

--- a/Targets/Domain/Sources/Entity/TagData.swift
+++ b/Targets/Domain/Sources/Entity/TagData.swift
@@ -12,6 +12,6 @@ import Foundation
 
 struct TagData: Tag {
     let id: Int
-    let name: String
-    let created: String
+    let userId: Int
+    let tagName: String
 }

--- a/Targets/Domain/Sources/Model/TagModel.swift
+++ b/Targets/Domain/Sources/Model/TagModel.swift
@@ -19,7 +19,7 @@ extension TagData {
             "마케팅", "서비스기획", "조직문화", "IT/기술", "취업 이직",
             "회사생활", "라이프스타일", "경영/젼략"
         ].enumerated().map({
-            .init(id: $0.offset, name: $0.element, created: Date(timeIntervalSinceNow: Double($0.offset)).description)
+            .init(id: $0.offset, userId: 1, tagName: $0.element)
         })
     }
 }
@@ -44,20 +44,81 @@ extension TagModel {
         
     }
     
-    public func create(_ item: Tag) {
-    
+    public func create(tagName: String) async throws {
+        let requestBody = CreateTagRequest.Body(tagName: tagName)
+        
+        let uploadTagRequest = CreateTagRequest(
+            accessToken: "accessToken",
+            body: requestBody
+        )
+        let result = await api.request(by: uploadTagRequest)
+        
+        do {
+            switch result {
+            case .success(_):
+                print("태그 추가 성공")
+            case .failure(let error):
+               throw error
+            }
+        } catch {
+            throw error
+        }
     }
     
-    public func read(_ item: Tag) {
+    public func read(page: Int, take: Int) async throws {
+        let readTagRequest = ReadTagRequest(accessToken: "accessToken", page: page, take: take)
+        let result = await api.request(by: readTagRequest)
+        
+        do {
+            switch result {
+            case .success(let data):
+                let response = try JSONDecoder().decode(ReadTagResponse.self, from: data)
+                self.items = response.tags.map {
+                    TagData(
+                        id: $0.id,
+                        userId: $0.userId,
+                        tagName: $0.tagName)
+                }
+            case .failure(let error):
+               throw error
+            }
+        } catch {
+            throw error
+        }
+    }
+    
+    public func update(tagId: Int, tagName: String) async throws {
+        let requestBody = UpdateTagRequest.Body(tagName: tagName)
+        
+        let updateTagRequest = UpdateTagRequest(accessToken: "accessToken", tagId: tagId, body: requestBody)
+        let result = await api.request(by: updateTagRequest)
+        
+        do {
+            switch result {
+            case .success(_):
+                print("태그 업데이트 성공")
+            case .failure(let error):
+               throw error
+            }
+        } catch {
+            throw error
+        }
         
     }
     
-    public func update(_ item: Tag) {
+    public func remove(tagId: Int) async throws {
+        let deleteTagRequest = DeleteTagRequest(accessToken: "accessToken", tagId: tagId)
+        let result = await api.request(by: deleteTagRequest)
         
+        do {
+            switch result {
+            case .success(_):
+                print("태그 제거 성공")
+            case .failure(let error):
+               throw error
+            }
+        } catch {
+            throw error
+        }
     }
-    
-    public func remove(_ item: Tag) {
-        
-    }
-    
 }

--- a/Targets/DomainInterface/Sources/Entity/Tag.swift
+++ b/Targets/DomainInterface/Sources/Entity/Tag.swift
@@ -9,6 +9,6 @@ import Foundation
 
 public protocol Tag {
     var id: Int { get }
-    var name: String { get }
-    var created: String { get }
+    var userId: Int { get }
+    var tagName: String { get }
 }

--- a/Targets/DomainInterface/Sources/Model/TagModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/TagModelProtocol.swift
@@ -11,8 +11,8 @@ import Combine
 public protocol TagModelProtocol {
     var itemsPublisher: Published<[Tag]>.Publisher { get }
     func fetch()
-    func create(_ item: Tag)
-    func read(_ item: Tag)
-    func update(_ item: Tag)
-    func remove(_ item: Tag)
+    func create(tagName: String) async throws
+    func read(page: Int, take: Int) async throws
+    func update(tagId: Int, tagName: String) async throws
+    func remove(tagId: Int) async throws
 }

--- a/Targets/UserInterface/Sources/ContentView.swift
+++ b/Targets/UserInterface/Sources/ContentView.swift
@@ -40,8 +40,8 @@ public struct ContentView: View {
 
 struct MockTag: Tag {
     var id: Int
-    var name: String
-    var created: String
+    var userId: Int
+    var tagName: String
 }
 
 struct MockArticle: Article {
@@ -55,6 +55,7 @@ struct MockArticle: Article {
 }
 
 struct MockLoginUser: LoginUser {
+    var userId: Int? = 1
     var nickName: String = ""
     var accessToken: String?
 }
@@ -75,13 +76,21 @@ final class MockTagModel: TagModelProtocol {
     var itemsPublisher: Published<[DomainInterface.Tag]>.Publisher { $items }
     
     func fetch() { }
-    func create(_ item: DomainInterface.Tag) { }
-    func read(_ item: DomainInterface.Tag) { }
-    func update(_ item: DomainInterface.Tag) { }
-    func remove(_ item: DomainInterface.Tag) { }
+    func create(tagName: String) async throws {}
+    func read(page: Int, take: Int) async throws {}
+    func update(tagId: Int, tagName: String) async throws {}
+    func remove(tagId: Int) async throws {}
 }
 
 final class MockLoginModel: LoginModelProtocol {
+    func isKakaoTalkLoginUrl(_ url: URL) -> Bool {
+        return true //FIXME: 다른 pr에서 수정 예정
+    }
+    
+    func authController(url: URL) -> Bool {
+        return true //FIXME: 다른 pr에서 수정 예정
+    }
+    
     @Published var userData: LoginUser = MockLoginUser()
     var userDataPublisher: Published<DomainInterface.LoginUser>.Publisher { $userData }
     

--- a/Targets/UserInterface/Sources/Home/HomeView.swift
+++ b/Targets/UserInterface/Sources/Home/HomeView.swift
@@ -59,7 +59,7 @@ private extension HomeView {
                                     HapticManager.instance.impact(style: .light)
                                     viewModel.selectedTag = row
                                 }, label: {
-                                    Text(row.name)
+                                    Text(row.tagName)
                                 }
                             )
                             .pretendFont(.body2)

--- a/Targets/UserInterface/Sources/Home/HomeViewModel.swift
+++ b/Targets/UserInterface/Sources/Home/HomeViewModel.swift
@@ -107,11 +107,15 @@ extension HomeViewModel {
 //        getTags()
     }
     
-    func removeTag(by id: Int){
-        guard let removingItem = tags.first(where: { $0.id == id }) else {
-            return
+    func removeTag(by id: Int) {
+        Task {
+            do {
+                try await modelContainer.tagModel.remove(tagId: id)
+            } catch {
+                print(error.localizedDescription)
+            }
         }
-        modelContainer.tagModel.remove(removingItem)
+        
 //        getTags()
     }
     


### PR DESCRIPTION
## 📌 배경

close #124 

## 내용
- Tag 통신 DTO (Request, Response) 작성
- DTO를 이용한 TagModel에 CRUD 작성
- 테스트 코드 작성

## 테스트 방법 (optional)
- APITests.swift에서 태그 관련 메소드 테스트
**`하지만 현재 포스트맨 및 테스트 코드에서 태그 관련 API들 모두 401 statusCode를 반환중(엑세스 토큰이나 서버분들께 문의 필요)`**