### PR TITLE
[Refactor] Home화면 ModelContainer 의존성 주입 시점 변경 (PR 재생성)

### DIFF
--- a/Targets/UserInterface/Sources/Home/HomeArticle/HomeArticleList.swift
+++ b/Targets/UserInterface/Sources/Home/HomeArticle/HomeArticleList.swift
@@ -66,7 +66,13 @@ struct HomeArticleList: View {
 
 struct HomeArticleList_Previews: PreviewProvider {
     static let homeViewModel: HomeViewModel = {
-        let vm = HomeViewModel()
+        let vm = HomeViewModel(
+            modelContainer: ModelContainer(
+                articleModel: MockArticleModel(),
+                tagModel: MockTagModel(),
+                loginModel: MockLoginModel()
+            )
+        )
         vm.articles = TemporaryArticle.allArticles
         return vm
     }()

--- a/Targets/UserInterface/Sources/Home/HomeView.swift
+++ b/Targets/UserInterface/Sources/Home/HomeView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 let tagHeight = 32
 
 struct HomeView: View {
-    @StateObject var viewModel = HomeViewModel()
+    @StateObject var viewModel: HomeViewModel
     @State var isFolding = false
     @State var isPushSearchView = false
     
@@ -111,7 +111,15 @@ private extension HomeView {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView()
+        HomeView(
+            viewModel: HomeViewModel(
+                modelContainer: ModelContainer(
+                    articleModel: MockArticleModel(),
+                    tagModel: MockTagModel(),
+                    loginModel: MockLoginModel()
+                )
+            )
+        )
     }
 }
 

--- a/Targets/UserInterface/Sources/Home/HomeViewModel.swift
+++ b/Targets/UserInterface/Sources/Home/HomeViewModel.swift
@@ -15,16 +15,17 @@ import DomainInterface
 
 final class HomeViewModel: ObservableObject {
     
-    @EnvironmentObject var modelContainer: ModelContainer
+    @ObservedObject var modelContainer: ModelContainer
     
     @Published var articles: [TemporaryArticle] = []
     @Published var rows: [[Tag]] = []
     @Published var tags: [Tag] = []
     @Published var tagText = ""
     
-    @Published var selectedTag: Tag!
+    @Published var selectedTag: Tag?
         
-    init() {
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
         modelContainer.tagModel.itemsPublisher
             .receive(on: RunLoop.main)
             .assign(to: &self.$tags)
@@ -32,7 +33,7 @@ final class HomeViewModel: ObservableObject {
         // Dummy Data 셋업
         articles = TemporaryArticle.allArticles
 //        getTags()
-        selectedTag = tags.first!
+        selectedTag = tags.first
     }
     
     /// 월별 데이터 정렬 메소드
@@ -90,11 +91,11 @@ final class HomeViewModel: ObservableObject {
 extension HomeViewModel {
     
     func tagButtonColor(by row: Tag) -> Color {
-        self.selectedTag.id == row.id ? Color.white : Color.grey4
+        self.selectedTag?.id == row.id ? Color.white : Color.grey4
     }
     
     func tagBackgroundColor(by row: Tag) -> Color {
-        self.selectedTag.id == row.id ? Color.ticlemoaBlack : Color.grey2
+        self.selectedTag?.id == row.id ? Color.ticlemoaBlack : Color.grey2
     }
     
 }

--- a/Targets/UserInterface/Sources/Login/LoginView.swift
+++ b/Targets/UserInterface/Sources/Login/LoginView.swift
@@ -38,6 +38,9 @@ struct LoginView: View {
             socialLoginButtons
             Spacer()
                 .frame(maxHeight: 58)
+            Button("임시 로그인 버튼") {
+                isLoggedIn = true
+            }
         }
     }
 }

--- a/Targets/UserInterface/Sources/MainTab/MainTabView.swift
+++ b/Targets/UserInterface/Sources/MainTab/MainTabView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @EnvironmentObject private var modelContainer: ModelContainer
     @State private var isSnackBarButtonExisting: Bool = UIPasteboard.general.string != nil // 복사된 텍스트가 있을 경우, true
     
     var body: some View {
         NavigationView {
             TabView {
-                HomeView()
+                HomeView(viewModel: HomeViewModel(modelContainer: modelContainer))
                 //                .setupBackground()
                     .tabItem {
                         Tab.home.imageItem


### PR DESCRIPTION
## 📌 배경

close #130 

## 내용
- **[Login화면 ModelContainer 의존성 주입 변경 PR](https://github.com/depromeet/ticlemoa-iOS/pull/118) 참고**
- **임시 로그인 버튼 추가**
- [Tag API CRUD PR](https://github.com/depromeet/ticlemoa-iOS/pull/129)에 체이닝
## 테스트 방법 
```swift
HomeView(
            viewModel: HomeViewModel(
                modelContainer: ModelContainer(
                    articleModel: MockArticleModel(),
                    tagModel: MockTagModel(),
                    loginModel: MockLoginModel()
                )
            )
        )
```