### PR TITLE
[Feature] 프로필 수정 화면에서 사진 설정 기능

### DIFF
--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
@@ -10,9 +10,32 @@ import SwiftUI
 
 final class ProfileSettingViewModel: ObservableObject {
     @ObservedObject var modelContainer: ModelContainer
+    @Published var isConfirmationDialogOpen: Bool = false
+    @Published var isImagePickerOpen: Bool = false
+    @Published var profileImageURL: URL?
+    @AppStorage("Moamoa.userProfileImageURL") private var userProfileImageURL: URL?
     
     init(modelContainer: ModelContainer) {
         self.modelContainer = modelContainer
     }
     
+    func profileImageTouched() {
+        isConfirmationDialogOpen = true
+    }
+    
+    func selectPhotoInAlbumButtonTouched() {
+        isImagePickerOpen = true
+    }
+    
+    func updateProfileImage(fromUrl url: URL) {
+        profileImageURL = url
+    }
+    
+    func resetImage() {
+        profileImageURL = nil
+    }
+    
+    func saveButtonTouched() {
+        userProfileImageURL = profileImageURL
+    }
 }


### PR DESCRIPTION
## 📌 배경

open #141

## 내용
- 프로필 수정 화면에서 사진 선택 기능
- viewModel에 userDefault 이용하여 사진 url 저장

## 테스트 방법 (optional)
- 앱 실행 > 마이페이지 > 사람모양 터치 > 사람모양 터치 > 이미지 선택 > pop까지 되면 성공

## 스크린샷 (optional)

<img width=300 src="https://user-images.githubusercontent.com/81242125/211209936-ac3d682b-b8a0-48b2-a843-e898ea607867.gif">

