### PR TITLE
[Feature] 마이페이지에서 사용자가 닉네임을 변경하는 기능

### DIFF
--- a/Targets/Domain/Sources/Model/LoginModel.swift
+++ b/Targets/Domain/Sources/Model/LoginModel.swift
@@ -36,10 +36,21 @@ public final class LoginModel: LoginModelProtocol {
     private let api: APIDetails = TiclemoaAPI()
     
     public init() {
+        #if DEBUG
+        self.prepareForDebugEnvorinment()
+        #endif
         self.userData = LoginUserData.shared
     }
     
 }
+
+#if DEBUG
+extension LoginModel {
+    private func prepareForDebugEnvorinment() {
+        LoginUserData.shared = LoginUserData(nickName: "가나다라마바사", accessToken: "accessToken", userId: 1, mail: "gd051234@gmail.com")
+    }
+}
+#endif
 
 extension LoginModel {
     
@@ -89,6 +100,18 @@ extension LoginModel {
                 print(error.localizedDescription)
                 return false
         }
+    }
+    
+    public func nicknameChangeTo(_ nickname: String) {
+        guard let oldValue = userData else { return } // TODO: 에러처리 필요
+        let newValue = LoginUserData(
+            nickName: nickname,
+            accessToken: oldValue.accessToken,
+            userId: oldValue.userId,
+            mail: oldValue.mail
+        )
+        userData = newValue
+        LoginUserData.shared = newValue
     }
     
     private func kakaoAccessToken() async -> Result<OAuthToken, Error> {

--- a/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
+++ b/Targets/DomainInterface/Sources/Model/LoginModelProtocol.swift
@@ -14,4 +14,5 @@ public protocol LoginModelProtocol {
     func isKakaoTalkLoginUrl(_ url: URL) -> Bool
     func authController(url: URL) -> Bool
     func requestAccessToken() async -> Bool
+    func nicknameChangeTo(_ nickname: String)
 }

--- a/Targets/UserInterface/Sources/ContentView.swift
+++ b/Targets/UserInterface/Sources/ContentView.swift
@@ -83,6 +83,10 @@ final class MockTagModel: TagModelProtocol {
 }
 
 final class MockLoginModel: LoginModelProtocol {
+    func nicknameChangeTo(_ nickname: String) {
+        Void()
+    }
+    
     @Published var userData: LoginUser? = MockLoginUser(
         nickName: "TestNickname", accessToken: "", userId: 0, mail: "ticlemoa@gmail.com"
     )

--- a/Targets/UserInterface/Sources/Scenes/MyPage/MyPageView.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/MyPageView.swift
@@ -42,13 +42,13 @@ struct MyPageView: View {
                     .padding(.top, 24)
                     .padding(.bottom, 12)
                     HStack(spacing: 2) {
-                        Text("가나다라마바사")
+                        Text(viewModel.nickName ?? "확인할 수 없음")
                             .pretendFont(.subhead3)
                             .foregroundColor(.ticlemoaBlack)
                         Image("Pen")
                             .frame(width: 20, height: 20)
                     }
-                    Text("asdf12345@gmail.com")
+                    Text(viewModel.email ?? "확인할 수 없음")
                         .pretendFont(.subhead2)
                         .tint(.grey3)
                         .padding(.top, 4)

--- a/Targets/UserInterface/Sources/Scenes/MyPage/MyPageViewModel.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/MyPageViewModel.swift
@@ -7,17 +7,29 @@
 //
 
 import SwiftUI
+import Combine
 
 final class MyPageViewModel: ObservableObject {
     @ObservedObject var modelContainer: ModelContainer
+    @Published var nickName: String?
+    @Published var email: String?
     @Published var profileImageURL: URL?
     @AppStorage("Moamoa.userProfileImageURL") private var userProfileImageURL: URL?
+    private var anyCancellables: [AnyCancellable] = []
     
     init(modelContainer: ModelContainer) {
         self.modelContainer = modelContainer
+        self.setupBinding()
     }
     
     func updateProfile() {
         profileImageURL = userProfileImageURL
+    }
+    
+    private func setupBinding() {
+        modelContainer.loginModel.userDataPublisher.sink { [weak self] loginUser in
+            self?.nickName = loginUser?.nickName
+            self?.email = loginUser?.mail
+        }.store(in: &anyCancellables)
     }
 }

--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingView.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingView.swift
@@ -7,11 +7,11 @@
 //
 
 import SwiftUI
+import Combine
 import PhotosUI
 
 struct ProfileSettingView: View {
     @ObservedObject var viewModel: ProfileSettingViewModel
-    @State private var nickname: String = ""
     @Environment(\.dismiss) private var dismiss
     
     init(viewModel: ProfileSettingViewModel) {
@@ -62,13 +62,16 @@ struct ProfileSettingView: View {
                     Spacer()
                 }
                 .padding(.bottom, 12)
-                TextField("닉네임을 입력해주세요.", text: self.$nickname)
+                TextField("닉네임을 입력해주세요.", text: $viewModel.nickname)
                     .padding(.bottom, 8)
+                    .onChange(of: viewModel.nickname.count) { _ in
+                        viewModel.nicknameTextfieldChanged()
+                    }
                 Divider()
                     .padding(.bottom, 8.8)
                 HStack {
                     Spacer()
-                    Text("\(nickname.count)/10")
+                    Text("\(viewModel.nickname.count)/10")
                         .foregroundColor(.grey4)
                         .font(.system(size: 14))
                 }

--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
@@ -13,6 +13,7 @@ final class ProfileSettingViewModel: ObservableObject {
     @Published var isConfirmationDialogOpen: Bool = false
     @Published var isImagePickerOpen: Bool = false
     @Published var profileImageURL: URL?
+    @Published var nickname: String = ""
     @AppStorage("Moamoa.userProfileImageURL") private var userProfileImageURL: URL?
     
     init(modelContainer: ModelContainer) {
@@ -22,6 +23,10 @@ final class ProfileSettingViewModel: ObservableObject {
     
     func profileImageTouched() {
         isConfirmationDialogOpen = true
+    }
+    
+    func nicknameTextfieldChanged() {
+        nickname = String(nickname.prefix(10))
     }
     
     func selectPhotoInAlbumButtonTouched() {
@@ -38,5 +43,6 @@ final class ProfileSettingViewModel: ObservableObject {
     
     func saveButtonTouched() {
         userProfileImageURL = profileImageURL
+        modelContainer.loginModel.nicknameChangeTo(nickname)
     }
 }


### PR DESCRIPTION
## 📌 배경

close #150

## 내용

- Debug mode에서 Debug용 dummy 넣음
- 프로필 화면에서 사용자 닉네임 확인 가능
- 프로필 설정 변경 화면에서 닉네임 변경시 변경된 닉네임으로 저장
- 프로필 설정 변경 화면에서 닉네임 10글자 이하로만 설정 가능하도록 함
- Domain model, DomainInterface에 함수 적용하여 실제로 닉네임이 변경되고, 저장되도록 함

## 스크린샷 (optional)
<img src="https://user-images.githubusercontent.com/81242125/211307297-d3b71c26-360d-463a-8d9e-020f3a4d166f.mp4">

- 은우님과 함께 작업했읍니다.


