### PR TITLE
[Fix] DomainInterfaceError 관련 컴파일 에러 처리

### DIFF
--- a/Targets/DomainInterface/Sources/DomainInterfaceError.swift
+++ b/Targets/DomainInterface/Sources/DomainInterfaceError.swift
@@ -1,8 +1,8 @@
 //
 //  DomainInterfaceError.swift
-//  DomainInterface
+//  Domain
 //
-//  Created by Joseph Cha on 2023/01/09.
+//  Created by Joseph Cha on 2023/01/10.
 //  Copyright © 2023 nyongnyong. All rights reserved.
 //
 


### PR DESCRIPTION
## 📌 배경

close #158 

## 내용
- DomainInterfaceError 파일이 Domain 모듈에 지정되어 있어 UserInterface에서 컴파일 에러 남
- DomainInterfaceError.swift 파일을 DomainInterface 모듈로 이동
