### PR TITLE
[Fix] 검색 화면에서 하단 탭바를 보이지 않게 처리

### DIFF
--- a/Targets/UserInterface/Sources/Scenes/MainTab/MainTabView.swift
+++ b/Targets/UserInterface/Sources/Scenes/MainTab/MainTabView.swift
@@ -20,9 +20,7 @@ struct MainTabView: View {
     var body: some View {
         NavigationView {
             TabView {
-                NavigationView {
-                    HomeView(viewModel: HomeViewModel(modelContainer: modelContainer))
-                }
+                HomeView(viewModel: HomeViewModel(modelContainer: modelContainer))
                 .tabItem {
                     Tab.home.imageItem
                     Tab.home.textItem


### PR DESCRIPTION
## 📌 배경

close #167

## 내용
- 홈 화면을 덮는 NavigationView를 TabBar를 덮도록 변경하여 해결

## 테스트 방법 (optional)
- 앱 실행 > 홈 > 검색에서 TabBar가 안보이면 성공!

## 스크린샷 (optional)

<img width=300 src= "https://user-images.githubusercontent.com/81242125/211558903-6b0f27d3-3679-43c2-850b-69ea9cf84e6a.png">

