### PR TITLE
[Feature] 마이페이지에서 닉네임 수정시 UI와 제약사항 설정

### DIFF
--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingView.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingView.swift
@@ -92,13 +92,16 @@ struct ProfileSettingView: View {
         .sheet(isPresented: $viewModel.isImagePickerOpen) {
             ImagePicker(viewModel: viewModel)
         }
-        .ticlemoaNavigationBar(title: "프로필 설정",
-                               image: "arrow") {
+        .ticlemoaNavigationBar(title: "프로필 설정", image: "arrow") {
             Button("완료") {
                 viewModel.saveButtonTouched()
+            }
+            .foregroundColor(viewModel.isSavable ? .ticlemoaPrimary : .black)
+        }
+        .onChange(of: viewModel.isPresented) { newValue in
+            if !newValue {
                 dismiss()
             }
-            .foregroundColor(.black)
         }
     }
 }

--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Combine
 
 final class ProfileSettingViewModel: ObservableObject {
     @ObservedObject var modelContainer: ModelContainer
@@ -15,10 +16,12 @@ final class ProfileSettingViewModel: ObservableObject {
     @Published var profileImageURL: URL?
     @Published var nickname: String = ""
     @AppStorage("Moamoa.userProfileImageURL") private var userProfileImageURL: URL?
+    private var anyCancellables: [AnyCancellable] = []
     
     init(modelContainer: ModelContainer) {
         self.modelContainer = modelContainer
         self.profileImageURL = userProfileImageURL
+        self.setupBinding()
     }
     
     func profileImageTouched() {
@@ -44,5 +47,13 @@ final class ProfileSettingViewModel: ObservableObject {
     func saveButtonTouched() {
         userProfileImageURL = profileImageURL
         modelContainer.loginModel.nicknameChangeTo(nickname)
+    }
+    
+    private func setupBinding() {
+        modelContainer.loginModel.userDataPublisher.sink { [weak self] loginUser in
+            if let savedNickname = loginUser?.nickName {
+                self?.nickname = savedNickname
+            }
+        }.store(in: &anyCancellables)
     }
 }

--- a/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Targets/UserInterface/Sources/Scenes/MyPage/ProfileSetting/ProfileSettingViewModel.swift
@@ -15,6 +15,8 @@ final class ProfileSettingViewModel: ObservableObject {
     @Published var isImagePickerOpen: Bool = false
     @Published var profileImageURL: URL?
     @Published var nickname: String = ""
+    @Published var isPresented: Bool = true
+    @Published var isSavable: Bool = false
     @AppStorage("Moamoa.userProfileImageURL") private var userProfileImageURL: URL?
     private var anyCancellables: [AnyCancellable] = []
     
@@ -45,8 +47,13 @@ final class ProfileSettingViewModel: ObservableObject {
     }
     
     func saveButtonTouched() {
-        userProfileImageURL = profileImageURL
-        modelContainer.loginModel.nicknameChangeTo(nickname)
+        if isSavable {
+            userProfileImageURL = profileImageURL
+            modelContainer.loginModel.nicknameChangeTo(nickname)
+            isPresented = false
+        } else {
+            // TODO: 없을 때 어떻게 해야할지 결정해야 함
+        }
     }
     
     private func setupBinding() {
@@ -54,6 +61,11 @@ final class ProfileSettingViewModel: ObservableObject {
             if let savedNickname = loginUser?.nickName {
                 self?.nickname = savedNickname
             }
+        }.store(in: &anyCancellables)
+        
+        $nickname.sink { [weak self] string in
+            guard let self = self else { return }
+            self.isSavable = !self.nickname.isEmpty && !self.nickname.contains(" ")
         }.store(in: &anyCancellables)
     }
 }


### PR DESCRIPTION
## 📌 배경

close #195

## 내용
- 마이페이지 수정 화면 진입시 닉네임 변경란에 현재 닉네임이 기입되어 있도록 하였습니다.
- 제약사항 만족시에만 완료 버튼이 동작합니다.
  - 완료버튼이 초록색이 됩니다.
  - 제약사항은 비어있지 않아야 하며 띄어쓰기가 없어야 하도록 하였습니다.
- 제약사항 불만족시 버튼을 눌렀을 때의 정책이 필요합니다.
  - 완료버튼이 검정색이 됩니다.
  - 완료버튼을 눌러도 아무런 동작을 하지 않습니다.

## 스크린샷 (optional)
<img width=300 src="https://user-images.githubusercontent.com/81242125/212008500-707fc3e8-2342-4047-a4f4-a462620f6ed2.gif">
