### PR TITLE
[Fix] 검색 화면에서 하단 탭바 보이지 않게 처리

### DIFF
--- a/Targets/UserInterface/Sources/Scenes/MainTab/MainTabView.swift
+++ b/Targets/UserInterface/Sources/Scenes/MainTab/MainTabView.swift
@@ -21,9 +21,7 @@ struct MainTabView: View {
     var body: some View {
         NavigationView {
             TabView(selection: $selection) {
-                NavigationView {
-                    HomeView(viewModel: HomeViewModel(modelContainer: modelContainer))
-                }
+                HomeView(viewModel: HomeViewModel(modelContainer: modelContainer))
                 .tabItem {
                     selection == 0 ? Image("home_selected") : Image("home_unselected")
                     Text("홈")


### PR DESCRIPTION
## 📌 배경

close #167

## 내용
- 검색 화면에서 하단 탭바 나타나지 않도록 함

## 테스트 방법 (optional)
- 앱 실행 > 플러스 버튼 > 아무 url 등록하여 저장하기 > 홈 화면 > 검색 > 탭바가 없으면 성공!

## 스크린샷 (optional)

|수정 전|수정 후|
|:-:|:-:|
|<img width=300 src="https://user-images.githubusercontent.com/81242125/212122455-4ea9c779-5eae-4693-bb78-32c7e9a8ffe4.png">|<img width=300 src="https://user-images.githubusercontent.com/81242125/212122284-c52a3a6e-254a-48e1-bb1a-5a3a05e87793.png">|