### PR TITLE
[Feature] 홈 화면에서 태그 펼치기 화살표 위치 조정

### DIFF
--- a/Targets/UserInterface/Sources/Home/HomeView.swift
+++ b/Targets/UserInterface/Sources/Home/HomeView.swift
@@ -34,7 +34,7 @@ private extension HomeView {
             .frame(height: 56)
             
             VStack(spacing: 0) {
-                ZStack {
+                ZStack(alignment: .top) {
                     if isFolding { /// 접혀 있을 경우 일직선 배열의 tagView
                         ScrollView(.horizontal, showsIndicators: false) {
                             LazyHStack(spacing: 10) {
@@ -81,7 +81,7 @@ private extension HomeView {
                         .padding(.vertical, 12)
                     }
                     /// folding button
-                    ZStack {
+                    if isFolding { /// 접혀 있는 경우 gradient 표시
                         HStack {
                             Spacer()
                             Rectangle().fill(
@@ -89,24 +89,26 @@ private extension HomeView {
                             )
                             .frame(width: 102, height: 37)
                         }
-                        
-                        HStack {
-                            Spacer()
-                            Button {
-                                withAnimation {
-                                    isFolding.toggle()
-                                }
-                            } label: {
-                                Group {
-                                    isFolding ? Image("arrow.down") : Image("arrow.up")
-                                }
-                                .padding(.trailing, 26.1)
+                        .padding(.top, 10)
+                    }
+                    HStack {
+                        Spacer()
+                        Button {
+                            withAnimation {
+                                isFolding.toggle()
                             }
+                        } label: {
+                            Group {
+                                isFolding ? Image("arrow.down") : Image("arrow.up")
+                            }
+                            .padding(.trailing, 26.1)
                         }
                     }
+                    .frame(height: 37)
+                    .padding(.top, 10)
                 }
                 
-                /// 잡햐쟈
+                /// tagManagingView
                 if !isFolding {
                     NavigationLink(isActive: $viewModel.isTagManagingViewPresented) {
                         TagManagingView()


### PR DESCRIPTION
## 📌 배경

close #250 

## 내용
- 태그 펼치기 버튼인 아랫방향 화살표를 눌러도 위치가 내려가지 않도록 함

## 테스트 방법 (optional)
- 태그가 충분히 존재하는 상황에서 태그 펼치기 버튼 터치

## 스크린샷 (optional)

|수정 전|수정 후|
|:-:|:-:|
|<img width=300 src="https://user-images.githubusercontent.com/81242125/222951517-c0b3ac07-421a-4ef9-83e4-bece18947939.gif">|<img width=300 src="https://user-images.githubusercontent.com/81242125/224527567-32e108dc-ae97-4886-bc91-87ade9d08e20.gif">|